### PR TITLE
Bug in LHSA to create uInd

### DIFF
--- a/Code/Source/svFSI/BAFINI.f
+++ b/Code/Source/svFSI/BAFINI.f
@@ -139,13 +139,15 @@
          i = 0
          DO a=1, tnNo
             IF (ISDOMAIN(1, a, phys_struct) .OR.
-     2          ISDOMAIN(1, a, phys_vms_struct)) i = i + 1
+     2          ISDOMAIN(1, a, phys_vms_struct) .OR.
+     3          ISDOMAIN(1, a, phys_lElas)) i = i + 1
          END DO
          ALLOCATE(gNodes(i))
          i = 0
          DO a=1, tnNo
             IF (ISDOMAIN(1, a, phys_struct) .OR.
-     2          ISDOMAIN(1, a, phys_vms_struct)) THEN
+     2          ISDOMAIN(1, a, phys_vms_struct) .OR.
+     3          ISDOMAIN(1, a, phys_lElas)) THEN
                i = i + 1
                gNodes(i) = a
             END IF

--- a/Code/Source/svFSI/DISTRIBUTE.f
+++ b/Code/Source/svFSI/DISTRIBUTE.f
@@ -576,8 +576,7 @@
          END IF
 
          IF (lEq%dmn(iDmn)%phys .EQ. phys_struct  .OR.
-     2       lEq%dmn(iDmn)%phys .EQ. phys_vms_struct .OR.
-     3       lEq%dmn(iDmn)%phys .EQ. phys_preSt) THEN
+     2       lEq%dmn(iDmn)%phys .EQ. phys_vms_struct) THEN
             CALL DIST_MATCONSTS(lEq%dmn(iDmn)%stM)
          END IF
 

--- a/Code/Source/svFSI/INITIALIZE.f
+++ b/Code/Source/svFSI/INITIALIZE.f
@@ -105,11 +105,6 @@
             dFlag = .TRUE.
             eq(iEq)%dof = nsd + 1
             eq(iEq)%sym = 'ST'
-         CASE (phys_preSt)
-            dFlag = .TRUE.
-            eq(iEq)%dof = nsd
-            eq(iEq)%am  = am
-            eq(iEq)%sym = 'PS'
          CASE (phys_CMM)
             dFlag = .TRUE.
             eq(iEq)%dof = nsd + 1

--- a/Code/Source/svFSI/LHSA.f
+++ b/Code/Source/svFSI/LHSA.f
@@ -211,6 +211,8 @@
          i = 0
          DO
             i = i + 1
+            IF (i .EQ. mnnzeic) CALL RESIZ()
+
 !           If current entry is zero, then  fill it up
             IF (uInd(i,row) .EQ. 0) THEN
                uInd(i,row) = col
@@ -234,7 +236,6 @@
             uInd(i,row) = col
             EXIT
          END DO
-         IF (i .EQ. mnnzeic) CALL RESIZ()
 
          RETURN
          END SUBROUTINE ADDCOL

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -146,7 +146,7 @@
      4   outGrp_hFlx = 508, outGrp_absV = 509, outGrp_stInv = 510,
      5   outGrp_vortex = 511, outGrp_trac = 512, outGrp_stress = 513,
      6   outGrp_fN = 514, outGrp_fA = 515, outGrp_J = 516, outGrp_F=517,
-     7   outGrp_Visc = 518
+     7   outGrp_divV = 518, outGrp_Visc = 519
 
       INTEGER, PARAMETER :: out_velocity = 599, out_pressure = 598,
      2   out_acceleration = 597, out_temperature = 596, out_WSS = 595,
@@ -155,7 +155,7 @@
      5   out_absVelocity = 588, out_vortex = 587, out_traction = 586,
      6   out_stress = 585, out_fibDir = 584, out_fibAlign = 583,
      7   out_actionPotential = 582, out_jacobian = 581, out_defGrad=580,
-     8   out_viscosity = 579
+     8   out_divergence = 579, out_viscosity = 578
 
 !     Mesher choice for remeshing for moving wall problems
       INTEGER, PARAMETER :: RMSH_TETGEN = 1, RMSH_MESHSIM = 2

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -96,8 +96,8 @@
       INTEGER, PARAMETER :: phys_NA = 200, phys_fluid = 201,
      2   phys_struct = 202, phys_heatS = 203, phys_lElas = 204,
      3   phys_heatF = 205, phys_FSI = 206, phys_mesh = 207,
-     4   phys_preSt = 208, phys_shell = 209, phys_CMM = 210,
-     5   phys_CEP = 211, phys_vms_struct = 212
+     4   phys_shell = 208, phys_CMM = 209, phys_CEP = 210,
+     5   phys_vms_struct = 211
 
 !     Differenty type of coupling for cplBC
 !     Not-available, implicit, semi-implicit, and explicit

--- a/Code/Source/svFSI/OUTPUT.f
+++ b/Code/Source/svFSI/OUTPUT.f
@@ -240,9 +240,8 @@
             IF ( (eq(iEq)%dmn(iDmn)%phys .NE. phys_struct) .AND.
      2           (eq(iEq)%dmn(iDmn)%phys .NE. phys_vms_struct) .AND.
      3           (eq(iEq)%dmn(iDmn)%phys .NE. phys_lElas)  .AND.
-     4           (eq(iEq)%dmn(iDmn)%phys .NE. phys_preSt) .AND.
-     5           (eq(iEq)%dmn(iDmn)%phys .NE. phys_shell) .AND.
-     6           (eq(iEq)%dmn(iDmn)%phys .NE. phys_CMM) ) CYCLE
+     4           (eq(iEq)%dmn(iDmn)%phys .NE. phys_shell) .AND.
+     5           (eq(iEq)%dmn(iDmn)%phys .NE. phys_CMM) ) CYCLE
             dnorm = Integ(eq(iEq)%dmn(iDmn)%Id, Dn, s, e)
             vol = eq(iEq)%dmn(iDmn)%v
             IF (.NOT.ISZERO(vol)) dnorm = dnorm / vol

--- a/Code/Source/svFSI/PIC.f
+++ b/Code/Source/svFSI/PIC.f
@@ -220,7 +220,8 @@ c         CALL IB_SETBCPEN()
          e = eq(2)%e
          DO Ac=1, tnNo
             IF (ISDOMAIN(cEq, Ac, phys_struct) .OR.
-     2          ISDOMAIN(cEq, Ac, phys_vms_struct)) THEN
+     2          ISDOMAIN(cEq, Ac, phys_vms_struct) .OR.
+     3          ISDOMAIN(cEq, Ac, phys_lElas)) THEN
                An(s:e,Ac) = An(1:nsd,Ac)
                Yn(s:e,Ac) = Yn(1:nsd,Ac)
                Dn(s:e,Ac) = Dn(1:nsd,Ac)

--- a/Code/Source/svFSI/PIC.f
+++ b/Code/Source/svFSI/PIC.f
@@ -169,7 +169,7 @@ c         CALL IB_SETBCPEN()
 
       LOGICAL :: l1, l2, l3, l4
       INTEGER :: s, e, a, Ac
-      REAL(KIND=8) :: coef(5), r1, r2, dUl(nsd)
+      REAL(KIND=8) :: coef(5), r1, dUl(nsd)
 
       s       = eq(cEq)%s
       e       = eq(cEq)%e

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -337,7 +337,7 @@
       TYPE(listType), INTENT(INOUT) :: list
       CHARACTER(LEN=stdL), INTENT(IN) :: eqName
 
-      INTEGER, PARAMETER :: maxOutput = 18
+      INTEGER, PARAMETER :: maxOutput = 19
 
       INTEGER fid, iBc, iBf, iM, iFa, phys(3), propL(maxNProp,10),
      2   outPuts(maxOutput), nDOP(4)
@@ -430,7 +430,7 @@
          IF (nsd .EQ. 3) propL(6,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
-         nDOP = (/10,2,3,0/)
+         nDOP = (/11,2,3,0/)
          outPuts(1)  = out_velocity
          outPuts(2)  = out_pressure
          outPuts(3)  = out_energyFlux
@@ -441,6 +441,7 @@
          outPuts(8)  = out_vortex
          outPuts(9)  = out_traction
          outPuts(10) = out_viscosity
+         outPuts(11) = out_divergence
 
          CALL READLS(lSolver_NS, lEq, list)
 
@@ -535,7 +536,7 @@
          IF (nsd .EQ. 3) propL(8,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
-         nDOP = (/11,1,0,0/)
+         nDOP = (/12,1,0,0/)
          outPuts(1)  = out_displacement
          outPuts(2)  = out_velocity
          outPuts(3)  = out_pressure
@@ -547,6 +548,7 @@
          outPuts(9)  = out_integ
          outPuts(10) = out_jacobian
          outPuts(11) = out_defGrad
+         outPuts(12) = out_divergence
 
          CALL READLS(lSolver_CG, lEq, list)
 
@@ -655,17 +657,18 @@
                propL(8,1) = elasticity_modulus
             END IF
 
-            nDOP = (/10,2,4,0/)
+            nDOP = (/11,2,4,0/)
             outPuts(1)  = out_velocity
             outPuts(2)  = out_pressure
             outPuts(3)  = out_energyFlux
-            outPuts(4)  = out_absVelocity
-            outPuts(5)  = out_acceleration
-            outPuts(6)  = out_WSS
-            outPuts(7)  = out_vorticity
+            outPuts(4)  = out_acceleration
+            outPuts(5)  = out_WSS
+            outPuts(6)  = out_vorticity
+            outPuts(7)  = out_vortex
             outPuts(8)  = out_displacement
             outPuts(9)  = out_strainInv
             outPuts(10) = out_viscosity
+            outPuts(11) = out_divergence
          ELSE
             propL(1,1) = poisson_ratio
             IF (.NOT.cmmVarWall) THEN
@@ -727,7 +730,7 @@
 
          CALL READDOMAIN(lEq, propL, list, phys)
 
-         nDOP = (/18,3,2,0/)
+         nDOP = (/19,3,2,0/)
          outPuts(1)  = out_velocity
          outPuts(2)  = out_pressure
          outPuts(3)  = out_displacement
@@ -746,6 +749,7 @@
          outPuts(16) = out_jacobian
          outPuts(17) = out_defGrad
          outPuts(18) = out_viscosity
+         outPuts(19) = out_divergence
 
          CALL READLS(lSolver_GMRES, lEq, list)
 
@@ -1025,7 +1029,6 @@
       TYPE(listType), INTENT(INOUT) :: list
 
       INTEGER lSolverType, FSILSType
-      LOGICAL flag
       CHARACTER(LEN=stdL) ctmp
       TYPE(listType), POINTER :: lPtr, lPL
 
@@ -1285,6 +1288,11 @@
             lEq%output(iOut)%o    = 0
             lEq%output(iOut)%l    = nsd*nsd
             lEq%output(iOut)%name = "Deformation_gradient"
+         CASE (out_divergence)
+            lEq%output(iOut)%grp  = outGrp_divV
+            lEq%output(iOut)%o    = 0
+            lEq%output(iOut)%l    = 1
+            lEq%output(iOut)%name = "Divergence"
          CASE (out_viscosity)
             lEq%output(iOut)%grp  = outGrp_Visc
             lEq%output(iOut)%o    = 0

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -339,7 +339,7 @@
 
       INTEGER, PARAMETER :: maxOutput = 19
 
-      INTEGER fid, iBc, iBf, iM, iFa, phys(3), propL(maxNProp,10),
+      INTEGER fid, iBc, iBf, iM, iFa, phys(4), propL(maxNProp,10),
      2   outPuts(maxOutput), nDOP(4)
       CHARACTER(LEN=stdL) ctmp
 
@@ -486,11 +486,18 @@
          IF (nsd .EQ. 3) propL(6,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
-         nDOP = (/4,1,0,0/)
-         outPuts(1) = out_displacement
-         outPuts(2) = out_velocity
-         outPuts(3) = out_acceleration
-         outPuts(4) = out_integ
+         lPtr => list%get(pstEq, "Prestress")
+         IF (pstEq) THEN
+            nDOP = (/2,2,0,0/)
+            outPuts(1) = out_displacement
+            outPuts(2) = out_stress
+         ELSE
+            nDOP = (/4,1,0,0/)
+            outPuts(1) = out_displacement
+            outPuts(2) = out_velocity
+            outPuts(3) = out_acceleration
+            outPuts(4) = out_integ
+         END IF
 
          CALL READLS(lSolver_CG, lEq, list)
 
@@ -507,17 +514,24 @@
          IF (nsd .EQ. 3) propL(7,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
-         nDOP = (/10,1,0,0/)
-         outPuts(1)  = out_displacement
-         outPuts(2)  = out_velocity
-         outPuts(3)  = out_acceleration
-         outPuts(4)  = out_stress
-         outPuts(5)  = out_fibDir
-         outPuts(6)  = out_fibAlign
-         outputs(7)  = out_strainInv
-         outPuts(8)  = out_integ
-         outPuts(9)  = out_jacobian
-         outPuts(10) = out_defGrad
+         lPtr => list%get(pstEq, "Prestress")
+         IF (pstEq) THEN
+            nDOP = (/2,2,0,0/)
+            outPuts(1) = out_displacement
+            outPuts(2) = out_stress
+         ELSE
+            nDOP = (/10,1,0,0/)
+            outPuts(1)  = out_displacement
+            outPuts(2)  = out_velocity
+            outPuts(3)  = out_acceleration
+            outPuts(4)  = out_stress
+            outPuts(5)  = out_fibDir
+            outPuts(6)  = out_fibAlign
+            outputs(7)  = out_strainInv
+            outPuts(8)  = out_integ
+            outPuts(9)  = out_jacobian
+            outPuts(10) = out_defGrad
+         END IF
 
          CALL READLS(lSolver_CG, lEq, list)
 
@@ -536,39 +550,27 @@
          IF (nsd .EQ. 3) propL(8,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
-         nDOP = (/12,1,0,0/)
-         outPuts(1)  = out_displacement
-         outPuts(2)  = out_velocity
-         outPuts(3)  = out_pressure
-         outPuts(4)  = out_acceleration
-         outPuts(5)  = out_stress
-         outPuts(6)  = out_fibDir
-         outPuts(7)  = out_fibAlign
-         outPuts(8)  = out_strainInv
-         outPuts(9)  = out_integ
-         outPuts(10) = out_jacobian
-         outPuts(11) = out_defGrad
-         outPuts(12) = out_divergence
-
-         CALL READLS(lSolver_CG, lEq, list)
-
-!     PRESTRESS equation solver---------------------
-      CASE ('prestress')
-         lEq%phys = phys_preSt
-         pstEq    = .TRUE.
-
-         propL(1,1) = solid_density
-         propL(2,1) = damping
-         propL(3,1) = elasticity_modulus
-         propL(4,1) = poisson_ratio
-         propL(5,1) = f_x
-         propL(6,1) = f_y
-         IF (nsd .EQ. 3) propL(7,1) = f_z
-         CALL READDOMAIN(lEq, propL, list)
-
-         nDOP = (/2,2,0,0/)
-         outPuts(1) = out_displacement
-         outPuts(2) = out_stress
+         lPtr => list%get(pstEq, "Prestress")
+         IF (pstEq) THEN
+            err = "Prestress for VMS_STRUCT is not implemented yet"
+            nDOP = (/2,2,0,0/)
+            outPuts(1) = out_displacement
+            outPuts(2) = out_stress
+         ELSE
+            nDOP = (/12,1,0,0/)
+            outPuts(1)  = out_displacement
+            outPuts(2)  = out_velocity
+            outPuts(3)  = out_pressure
+            outPuts(4)  = out_acceleration
+            outPuts(5)  = out_stress
+            outPuts(6)  = out_fibDir
+            outPuts(7)  = out_fibAlign
+            outPuts(8)  = out_strainInv
+            outPuts(9)  = out_integ
+            outPuts(10) = out_jacobian
+            outPuts(11) = out_defGrad
+            outPuts(12) = out_divergence
+         END IF
 
          CALL READLS(lSolver_CG, lEq, list)
 
@@ -589,10 +591,18 @@
          propL(8,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
-         nDOP = (/3,1,0,0/)
-         outPuts(1) = out_displacement
-         outPuts(2) = out_velocity
-         outPuts(3) = out_integ
+         lPtr => list%get(pstEq, "Prestress")
+         IF (pstEq) THEN
+            err = "Prestress for SHELLS is not implemented yet"
+            nDOP = (/2,2,0,0/)
+            outPuts(1) = out_displacement
+            outPuts(2) = out_stress
+         ELSE
+            nDOP = (/3,1,0,0/)
+            outPuts(1) = out_displacement
+            outPuts(2) = out_velocity
+            outPuts(3) = out_integ
+         END IF
 
          CALL READLS(lSolver_CG, lEq, list)
 
@@ -696,10 +706,11 @@
          mvMsh = .TRUE.
          lEq%phys = phys_FSI
 
-!        3 possible equations: fluid (must), struct/vms_struct
+!        3 possible equations: fluid (must), struct/vms_struct/lElas
          phys(1) = phys_fluid
          phys(2) = phys_struct
          phys(3) = phys_vms_struct
+         phys(4) = phys_lElas
 
 !        fluid properties
          propL(1,1) = fluid_density
@@ -727,6 +738,14 @@
          propL(6,3) = f_x
          propL(7,3) = f_y
          IF (nsd .EQ. 3) propL(8,3) = f_z
+
+!        lElas properties
+         propL(1,4) = solid_density
+         propL(2,4) = elasticity_modulus
+         propL(3,4) = poisson_ratio
+         propL(4,4) = f_x
+         propL(5,4) = f_y
+         IF (nsd .EQ. 3) propL(6,4) = f_z
 
          CALL READDOMAIN(lEq, propL, list, phys)
 
@@ -927,9 +946,11 @@
             CASE("vms_struct")
                lEq%dmn(iDmn)%phys = phys_vms_struct
                IF (.NOT.sstEq) sstEq = .TRUE.
+            CASE("lElas")
+               lEq%dmn(iDmn)%phys = phys_lElas
             CASE DEFAULT
                err = TRIM(lPD%ping("Equation",lPtr))//
-     2            "Equation must be fluid/struct/vms_struct"
+     2            "Equation must be fluid/struct/vms_struct/lElas"
             END SELECT
          ELSE
             lEq%dmn(iDmn)%phys = lEq%phys
@@ -1001,8 +1022,7 @@
          END IF
 
          IF (lEq%dmn(iDmn)%phys.EQ.phys_struct  .OR.
-     2       lEq%dmn(iDmn)%phys.EQ.phys_vms_struct .OR.
-     3       lEq%dmn(iDmn)%phys.EQ.phys_preSt) THEN
+     2       lEq%dmn(iDmn)%phys.EQ.phys_vms_struct) THEN
             CALL READMATMODEL(lEq%dmn(iDmn), lPD)
          END IF
 

--- a/Code/Source/svFSI/TXT.f
+++ b/Code/Source/svFSI/TXT.f
@@ -115,7 +115,7 @@
                   tmpV(1,a) = SQRT(NORM(tmpV(1:nsd,a)))
                END DO
                l = 1
-            CASE (outGrp_eFlx, outGrp_hFlx)
+            CASE (outGrp_eFlx, outGrp_hFlx, outGrp_divV, outGrp_J)
                CALL ALLPOST(tmpV, Yn, Dn, oGrp, iEq)
             CASE (outGrp_absV)
                DO a=1, tnNo

--- a/Code/Source/svFSI/VTKXML.f
+++ b/Code/Source/svFSI/VTKXML.f
@@ -640,6 +640,16 @@
                   END DO
                   DEALLOCATE(tmpV)
                   ALLOCATE(tmpV(maxnsd,msh(iM)%nNo))
+               CASE (outGrp_divV)
+                  IF (ALLOCATED(tmpV)) DEALLOCATE(tmpV)
+                  ALLOCATE(tmpV(1,msh(iM)%nNo))
+                  tmpV = 0D0
+                  CALL DIVPOST(msh(iM), tmpV, lY, lD, iEq)
+                  DO a=1, msh(iM)%nNo
+                     d(iM)%x(is,a) = tmpV(1,a)
+                  END DO
+                  DEALLOCATE(tmpV)
+                  ALLOCATE(tmpV(maxnsd,msh(iM)%nNo))
                CASE DEFAULT
                   err = "Undefined output"
                END SELECT

--- a/Code/Source/svFSI/VTKXML.f
+++ b/Code/Source/svFSI/VTKXML.f
@@ -559,10 +559,8 @@
                CASE (outGrp_stress)
                   IF (ALLOCATED(tmpV)) DEALLOCATE(tmpV)
                   ALLOCATE(tmpV(nstd,msh(iM)%nNo))
-                  IF (eq(iEq)%phys .EQ. phys_struct .OR.
-     2                eq(iEq)%phys .EQ. phys_vms_struct) THEN
-                     tmpV = 0D0
-                  ELSE IF (pstEq) THEN
+                  tmpV = 0D0
+                  IF (pstEq) THEN
                      DO a=1, msh(iM)%nNo
                         Ac = msh(iM)%gN(a)
                         tmpV(:,a) = pS0(:,Ac)


### PR DESCRIPTION
A bug was found in LHSA that can lead to inaccurate assembly of matrix for some meshes with a large nodal connectivity.

Other additions include modifying prestress inputs, linear elasticity to also be included for prestress and output divergence of velocity for fluid, FSI and VMS_STRUCT physics