### PR TITLE
DEV: ability to initialize RCR from flow/user-input

### DIFF
--- a/Code/Source/svFSI/BAFINI.f
+++ b/Code/Source/svFSI/BAFINI.f
@@ -92,11 +92,13 @@
                   cplBC%fa(i)%RCR%C  = eq(iEq)%bc(iBc)%RCR%C
                   cplBC%fa(i)%RCR%Rd = eq(iEq)%bc(iBc)%RCR%Rd
                   cplBC%fa(i)%RCR%Pd = eq(iEq)%bc(iBc)%RCR%Pd
+                  cplBC%fa(i)%RCR%Xo = eq(iEq)%bc(iBc)%RCR%Xo
                ELSE
                   err = "Not a compatible cplBC_type"
                END IF
             END IF
          END DO
+         IF (.NOT.stFileFlag) CALL RCRINIT()
          IF (cplBC%useGenBC) CALL genBC_Integ_X('I')
          IF (cplBC%schm .NE. cplBC_E) CALL CALCDERCPLBC()
       END IF

--- a/Code/Source/svFSI/DISTRIBUTE.f
+++ b/Code/Source/svFSI/DISTRIBUTE.f
@@ -357,6 +357,7 @@
          IF (.NOT.ALLOCATED(cplBC%xo)) ALLOCATE(cplBC%xo(cplBC%nX))
          IF (cplBC%nX .NE. 0) CALL cm%bcast(cplBC%xo)
       END IF
+      CALL cm%bcast(cplBC%initRCR)
 
       DO iM=1, nMsh
          CALL DESTROY(tMs(iM))
@@ -672,6 +673,7 @@
          CALL cm%bcast(lBc%RCR%C)
          CALL cm%bcast(lBC%RCR%Rd)
          CALL cm%bcast(lBC%RCR%Pd)
+         CALL cm%bcast(lBC%RCR%Xo)
       END IF
 
 !     Communicating time-dependent BC data

--- a/Code/Source/svFSI/INITIALIZE.f
+++ b/Code/Source/svFSI/INITIALIZE.f
@@ -279,7 +279,11 @@
                IF (flag) THEN
                   CALL INITFROMBIN(fTmp, timeP)
                ELSE
-                  IF (cm%mas()) wrn = TRIM(fTmp)//" can not be opened"
+                  IF (cm%mas()) THEN
+                     wrn = TRIM(fTmp)//" can not be opened. "//
+     2                  "Resetting restart flag to false"
+                  END IF
+                  stFileFlag = .FALSE.
                   CALL ZEROINIT(timeP)
                END IF
                IF (rmsh%isReqd) THEN

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -141,6 +141,8 @@
          REAL(KIND=RKIND) :: Rd = 0._RKIND
 !        Distal pressure
          REAL(KIND=RKIND) :: Pd = 0._RKIND
+!        Initial value
+         REAL(KIND=RKIND) :: Xo = 0._RKIND
       END TYPE rcrType
 
 !     Fourier coefficients that are used to specify unsteady BCs
@@ -452,6 +454,8 @@
          LOGICAL :: coupled = .FALSE.
 !        Whether to use genBC
          LOGICAL :: useGenBC = .FALSE.
+!        Whether to initialize RCR from flow data
+         LOGICAL :: initRCR = .FALSE.
 !        Number of coupled faces
          INTEGER(KIND=IKIND) :: nFa = 0
 !        Number of unknowns in the 0D domain

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -904,6 +904,7 @@
          cplBC%xo = 0._RKIND
          cplBC%xp = 0._RKIND
          cplBC%saveName = TRIM(appPath)//"RCR.dat"
+         lPtr => list%get(cplBC%initRCR, "Initialize RCR from flow")
       END IF
 !--------------------------------------------------------------------
 !     Searching for body forces
@@ -1640,6 +1641,7 @@
          lBc%RCR%C  = RCR(2)
          lBc%RCR%Rd = RCR(3)
          lPtr => list%get(lBc%RCR%Pd, "Distal pressure")
+         lPtr => list%get(lBc%RCR%Xo, "Initial pressure")
 
          IF (cplBC%schm.NE.cplBC_NA .OR. ALLOCATED(cplBC%xo)) err =
      2      "RCR cannot be used in conjunction with cplBC."

--- a/Code/Source/svFSI/SETBC.f
+++ b/Code/Source/svFSI/SETBC.f
@@ -1140,6 +1140,38 @@
       RETURN
       END SUBROUTINE cplBC_Integ_X
 !--------------------------------------------------------------------
+!     Initialize RCR variables (Xo) from flow field or using user-
+!     provided input. This subroutine is called only when the simulation
+!     is not restarted.
+      SUBROUTINE RCRINIT()
+      USE COMMOD
+      USE ALLFUN
+      IMPLICIT NONE
+      INTEGER(KIND=IKIND), PARAMETER :: iEq = 1
+
+      INTEGER(KIND=IKIND) iBc, iFa, iM, ptr
+      REAL(KIND=RKIND) :: area, Qo, Po
+
+      DO iBc=1, eq(iEq)%nBc
+         iFa = eq(iEq)%bc(iBc)%iFa
+         iM  = eq(iEq)%bc(iBc)%iM
+         ptr = eq(iEq)%bc(iBc)%cplBCptr
+         IF (.NOT.BTEST(eq(iEq)%bc(iBc)%bType,bType_RCR)) CYCLE
+         IF (ptr .NE. 0) THEN
+            IF (cplBC%initRCR) THEN
+               area = msh(iM)%fa(iFa)%area
+               Qo = Integ(msh(iM)%fa(iFa), Yo, 1, nsd)
+               Po = Integ(msh(iM)%fa(iFa), Yo, nsd+1)  / area
+               cplBC%xo(ptr) = Po - (Qo * cplBC%fa(ptr)%RCR%Rp)
+            ELSE
+               cplBC%xo(ptr) = cplBC%fa(ptr)%RCR%Xo
+            END IF
+         END IF
+      END DO
+
+      RETURN
+      END SUBROUTINE RCRINIT
+!--------------------------------------------------------------------
       SUBROUTINE RCR_Integ_X(istat)
       USE TYPEMOD
       USE COMMOD, ONLY : dt, time, cplBC

--- a/Code/Source/svFSI/TXT.f
+++ b/Code/Source/svFSI/TXT.f
@@ -73,10 +73,12 @@
                   END IF
                ELSE
                   OPEN(fid, FILE=cplBC%saveName, POSITION='APPEND')
+                  WRITE(fid,'(ES14.6E2)',ADVANCE='NO') cplBC%xp(1)
                   DO i=1, cplBC%nX
-                     WRITE(fid,'(ES14.6E2)',ADVANCE='NO') cplBC%xo(i)
+                     WRITE(fid,'(2(X,ES14.6E2))',ADVANCE='NO')
+     2                  cplBC%xn(i), cplBC%fa(i)%y
                   END DO
-                  DO i=1, cplBC%nXp
+                  DO i=2, cplBC%nXp
                      WRITE(fid,'(ES14.6E2)',ADVANCE='NO') cplBC%xp(i)
                   END DO
                   WRITE(fid,*)


### PR DESCRIPTION
The current code initializes RCR pressures to 0. This may lead to negative unphysiological pressures when a user initializes flow field (velocity/pressure) from a previous simulation for e.g., from a previous steady flow.

In this commit, we provide two options to initialize RCR pressure:
(a) Directly provide it in the input file. For example,

   Add BC: outlet {
      Type: Neumann
      Time dependence: RCR
      RCR values: (1.0, 0.02, 50.0)
      Distal pressure: 0.0
      **Initial pressure: 0.0**
   }

(b) Input command to initialize RCR from flow field. The RCR variable is initialized using the mean pressure on that face and the flow going through it (Xo = P - Rp*Q). For example, 

   **Initialize RCR from flow: t**
