### PR TITLE
Fiber stress and bug fix for saving time-averaged results

### DIFF
--- a/Code/Source/svFSI/ALLFUN.f
+++ b/Code/Source/svFSI/ALLFUN.f
@@ -1297,6 +1297,13 @@
       lDmn%stM%afs     = 0._RKIND
       lDmn%stM%bfs     = 0._RKIND
 
+      lDmn%stM%Tf%g     = 0._RKIND
+      lDmn%stM%Tf%fType = 0
+      IF (ALLOCATED(lDmn%stM%Tf%gt%qi)) DEALLOCATE(lDmn%stM%Tf%gt%qi)
+      IF (ALLOCATED(lDmn%stM%Tf%gt%qs)) DEALLOCATE(lDmn%stM%Tf%gt%qs)
+      IF (ALLOCATED(lDmn%stM%Tf%gt%r))  DEALLOCATE(lDmn%stM%Tf%gt%r)
+      IF (ALLOCATED(lDmn%stM%Tf%gt%i))  DEALLOCATE(lDmn%stM%Tf%gt%i)
+
       ! lDmn%cep
       lDmn%cep%cepType  = cepModel_NA
       lDmn%cep%Diso     = 0._RKIND

--- a/Code/Source/svFSI/DISTRIBUTE.f
+++ b/Code/Source/svFSI/DISTRIBUTE.f
@@ -1035,6 +1035,8 @@
       IMPLICIT NONE
       TYPE(stModelType), INTENT(INOUT) :: lStM
 
+      INTEGER(KIND=IKIND) i, j
+
       CALL cm%bcast(lStM%volType)
       CALL cm%bcast(lStM%Kpen)
       CALL cm%bcast(lStM%isoType)
@@ -1049,7 +1051,30 @@
       CALL cm%bcast(lStM%afs)
       CALL cm%bcast(lStM%bfs)
       CALL cm%bcast(lStM%kap)
-      CALL cm%bcast(lStM%Tf)
+
+!     Distribute fiber stress
+      CALL cm%bcast(lStM%Tf%fType)
+      IF (BTEST(lStM%Tf%fType, bType_std)) THEN
+         CALL cm%bcast(lStM%Tf%g)
+      ELSE IF (BTEST(lStM%Tf%fType, bType_ustd)) THEN
+         CALL cm%bcast(lStM%Tf%gt%lrmp)
+         CALL cm%bcast(lStM%Tf%gt%d)
+         CALL cm%bcast(lStM%Tf%gt%n)
+         j = lStM%Tf%gt%d
+         i = lStM%Tf%gt%n
+         IF (cm%slv()) THEN
+            ALLOCATE(lStM%Tf%gt%qi(j))
+            ALLOCATE(lStM%Tf%gt%qs(j))
+            ALLOCATE(lStM%Tf%gt%r(j,i))
+            ALLOCATE(lStM%Tf%gt%i(j,i))
+         END IF
+         CALL cm%bcast(lStM%Tf%gt%ti)
+         CALL cm%bcast(lStM%Tf%gt%T)
+         CALL cm%bcast(lStM%Tf%gt%qi)
+         CALL cm%bcast(lStM%Tf%gt%qs)
+         CALL cm%bcast(lStM%Tf%gt%r)
+         CALL cm%bcast(lStM%Tf%gt%i)
+      END IF
 
       RETURN
       END SUBROUTINE DIST_MATCONSTS

--- a/Code/Source/svFSI/DISTRIBUTE.f
+++ b/Code/Source/svFSI/DISTRIBUTE.f
@@ -1049,6 +1049,7 @@
       CALL cm%bcast(lStM%afs)
       CALL cm%bcast(lStM%bfs)
       CALL cm%bcast(lStM%kap)
+      CALL cm%bcast(lStM%Tf)
 
       RETURN
       END SUBROUTINE DIST_MATCONSTS

--- a/Code/Source/svFSI/MAIN.f
+++ b/Code/Source/svFSI/MAIN.f
@@ -251,7 +251,7 @@
             l3 = cTS .GE. saveATS
             IF (l2 .AND. l3) THEN
                CALL OUTRESULT(timeP, 3, iEqOld)
-               CALL WRITEVTUS(An, Yn, Dn)
+               CALL WRITEVTUS(An, Yn, Dn, .FALSE.)
                IF (ibFlag) CALL IB_WRITEVTUS(ib%Yb, ib%Ubo)
             ELSE
                CALL OUTRESULT(timeP, 2, iEqOld)

--- a/Code/Source/svFSI/MATMODELS.f
+++ b/Code/Source/svFSI/MATMODELS.f
@@ -68,7 +68,9 @@
       stM  = lDmn%stM
       nd   = REAL(nsd, KIND=RKIND)
       Kp   = stM%Kpen
-      Tfa  = stM%Tf
+
+!     Fiber-reinforced stress
+      CALL GETFIBSTRESS(stM%Tf, Tfa)
 
 !     Electromechanics coupling - active stress
       IF (cem%aStress) Tfa = Tfa + ya
@@ -427,7 +429,9 @@
 !     Some preliminaries
       stM  = lDmn%stM
       nd   = REAL(nsd, KIND=RKIND)
-      Tfa  = stM%Tf
+
+!     Fiber-reinforced stress
+      CALL GETFIBSTRESS(stM%Tf, Tfa)
 
 !     Electromechanics coupling - active stress
       IF (cem%aStress) Tfa = Tfa + ya
@@ -776,7 +780,7 @@
 
       RETURN
       END SUBROUTINE GETTAU
-!--------------------------------------------------------------------
+!####################################################################
 !     Convert elasticity tensor to Voigt notation
       SUBROUTINE CCTOVOIGT(CC, Dm)
       USE COMMOD, ONLY : RKIND, nsd, nsymd
@@ -838,6 +842,25 @@
 
       RETURN
       END SUBROUTINE CCTOVOIGT
+!####################################################################
+!     Compute additional fiber-reinforcement stress
+      SUBROUTINE GETFIBSTRESS(Tfl, g)
+      USE COMMOD
+      IMPLICIT NONE
+      TYPE(fibStrsType), INTENT(IN) :: Tfl
+      REAL(KIND=RKIND), INTENT(OUT) :: g
+
+      REAL(KIND=RKIND) rtmp
+
+      g = 0._RKIND
+      IF (BTEST(Tfl%fType, bType_std)) THEN
+         g = Tfl%g
+      ELSE IF (BTEST(Tfl%fType, bType_ustd)) THEN
+         CALL IFFT(Tfl%gt, g, rtmp)
+      END IF
+
+      RETURN
+      END SUBROUTINE GETFIBSTRESS
 !####################################################################
 !     Compute active component of deformation gradient tensor for
 !     electromechanics coupling based on active strain formulation

--- a/Code/Source/svFSI/MATMODELS.f
+++ b/Code/Source/svFSI/MATMODELS.f
@@ -49,7 +49,7 @@
 
       TYPE(stModelType) :: stM
       REAL(KIND=RKIND) :: nd, Kp, J, J2d, J4d, trE, p, pl, Inv1, Inv2,
-     2   Inv4, Inv6, Inv8, IDm(nsd,nsd), C(nsd,nsd), E(nsd,nsd),
+     2   Inv4, Inv6, Inv8, Tfa, IDm(nsd,nsd), C(nsd,nsd), E(nsd,nsd),
      3   Ci(nsd,nsd), Sb(nsd,nsd), CCb(nsd,nsd,nsd,nsd),
      3   PP(nsd,nsd,nsd,nsd), CC(nsd,nsd,nsd,nsd)
       REAL(KIND=RKIND) :: r1, r2, g1, g2, g3
@@ -68,8 +68,12 @@
       stM  = lDmn%stM
       nd   = REAL(nsd, KIND=RKIND)
       Kp   = stM%Kpen
+      Tfa  = stM%Tf
 
-!     Electromechanics coupling based on active strain
+!     Electromechanics coupling - active stress
+      IF (cem%aStress) Tfa = Tfa + ya
+
+!     Electromechanics coupling - active strain
       Fe   = F
       Fa   = MAT_ID(nsd)
       Fai  = Fa
@@ -126,6 +130,9 @@
          g1 = 2._RKIND * stM%C10
          Sb = g1*IDm
 
+!        Fiber reinforcement/active stress
+         Sb = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+
          r1 = g1*Inv1/nd
          S  = J2d*Sb - r1*Ci
          CC = (-2._RKIND/nd) * ( TEN_DYADPROD(Ci, S, nsd) +
@@ -140,6 +147,9 @@
          g1  = 2._RKIND * (stM%C10 + Inv1*stM%C01)
          g2  = -2._RKIND * stM%C01
          Sb  = g1*IDm + g2*J2d*C
+
+!        Fiber reinforcement/active stress
+         Sb  = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
 
          g1  = 4._RKIND*J4d* stM%C01
          CCb = g1 * (TEN_DYADPROD(IDm, IDm, nsd) - TEN_IDs(nsd))
@@ -179,6 +189,9 @@
          g2   = stM%aff * Eff * EXP(stM%bff*Eff*Eff)
          g3   = stM%ass * Ess * EXP(stM%bss*Ess*Ess)
          Sb   = 2._RKIND*(g1*IDm + g2*Hff + g3*Hss)
+
+!        Fiber reinforcement/active stress
+         Sb   = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
 
          g1   = stM%aff*(1._RKIND + 2._RKIND*stM%bff*Eff*Eff)*
      2      EXP(stM%bff*Eff*Eff)
@@ -248,6 +261,9 @@
          CCb = 2._RKIND*TEN_DYADPROD(Sb, Sb, nsd)
          Sb  = Sb * r2
 
+!        Fiber reinforcement/active stress
+         Sb  = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+
          r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
          S   = J2d*Sb - r1*Ci
 
@@ -296,7 +312,10 @@
      2          g2 * TEN_DYADPROD(Hfs, Hfs, nsd)
 
          IF (Eff .GT. 0._RKIND) THEN
-             g1  = 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff)
+!            Fiber reinforcement/active stress
+             g1  = Tfa
+
+             g1  = g1 + 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff)
              Hff = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
              Sb  = Sb + g1*Hff
 
@@ -390,7 +409,7 @@
 
       TYPE(stModelType) :: stM
       REAL(KIND=RKIND) :: nd, J, J2d, J4d, trE, Inv1, Inv2, Inv4, Inv6,
-     2   Inv8, IDm(nsd,nsd), C(nsd,nsd), E(nsd,nsd), Ci(nsd,nsd),
+     2   Inv8, Tfa, IDm(nsd,nsd), C(nsd,nsd), E(nsd,nsd), Ci(nsd,nsd),
      3   Sb(nsd,nsd), CCb(nsd,nsd,nsd,nsd), PP(nsd,nsd,nsd,nsd),
      4   CC(nsd,nsd,nsd,nsd)
       REAL(KIND=RKIND) :: r1, r2, g1, g2, g3
@@ -408,8 +427,12 @@
 !     Some preliminaries
       stM  = lDmn%stM
       nd   = REAL(nsd, KIND=RKIND)
+      Tfa  = stM%Tf
 
-!     Electromechanics coupling based on active strain
+!     Electromechanics coupling - active stress
+      IF (cem%aStress) Tfa = Tfa + ya
+
+!     Electromechanics coupling - active strain
       Fe   = F
       Fa   = MAT_ID(nsd)
       Fai  = Fa
@@ -440,6 +463,9 @@
          g1 = 2._RKIND * stM%C10
          Sb = g1*IDm
 
+!        Fiber reinforcement/active stress
+         Sb = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+
          r1 = g1*Inv1/nd
          S  = J2d*Sb - r1*Ci
          CC = 2._RKIND*r1 * ( TEN_SYMMPROD(Ci, Ci, nsd) -
@@ -452,6 +478,9 @@
          g1  = 2._RKIND * (stM%C10 + Inv1*stM%C01)
          g2  = -2._RKIND * stM%C01
          Sb  = g1*IDm + g2*J2d*C
+
+!        Fiber reinforcement/active stress
+         Sb  = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
 
          g1  = 4._RKIND*J4d* stM%C01
          CCb = g1 * (TEN_DYADPROD(IDm, IDm, nsd) - TEN_IDs(nsd))
@@ -489,6 +518,9 @@
          g2   = stM%aff * Eff * EXP(stM%bff*Eff*Eff)
          g3   = stM%ass * Ess * EXP(stM%bss*Ess*Ess)
          Sb   = 2._RKIND*(g1*IDm + g2*Hff + g3*Hss)
+
+!        Fiber reinforcement/active stress
+         Sb   = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
 
          g1   = stM%aff*(1._RKIND + 2._RKIND*stM%bff*Eff*Eff)*
      2      EXP(stM%bff*Eff*Eff)
@@ -556,6 +588,9 @@
          CCb = 2._RKIND*TEN_DYADPROD(Sb, Sb, nsd)
          Sb  = Sb * r2
 
+!        Fiber reinforcement/active stress
+         Sb  = Sb + Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+
          r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
          S   = J2d*Sb - r1*Ci
 
@@ -601,7 +636,10 @@
      2          g2 * TEN_DYADPROD(Hfs, Hfs, nsd)
 
          IF (Eff .GT. 0._RKIND) THEN
-             g1  = 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff)
+!            Fiber reinforcement/active stress
+             g1  = Tfa
+
+             g1  = g1 + 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff)
              Hff = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
              Sb  = Sb + g1*Hff
 
@@ -800,48 +838,6 @@
 
       RETURN
       END SUBROUTINE CCTOVOIGT
-!####################################################################
-!     Compute active stress for electromechanics
-      SUBROUTINE ACTVSTRESS(Tact, nfd, fl, S)
-      USE MATFUN
-      USE COMMOD
-      IMPLICIT NONE
-      INTEGER(KIND=IKIND), INTENT(IN) :: nfd
-      REAL(KIND=RKIND), INTENT(IN) :: Tact, fl(nsd,nfd)
-      REAL(KIND=RKIND), INTENT(INOUT) :: S(nsd,nsd)
-
-      S = S + Tact*MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
-
-      RETURN
-      END SUBROUTINE ACTVSTRESS
-!--------------------------------------------------------------------
-!     Compute deviatoric component of active stress for electromechanics
-      SUBROUTINE ACTVSTRSdev(Tact, F, nfd, fl, S)
-      USE MATFUN
-      USE COMMOD
-      IMPLICIT NONE
-      INTEGER(KIND=IKIND), INTENT(IN) :: nfd
-      REAL(KIND=RKIND), INTENT(IN) :: Tact, F(nsd,nsd), fl(nsd,nfd)
-      REAL(KIND=RKIND), INTENT(INOUT) :: S(nsd,nsd)
-
-      REAL(KIND=RKIND) :: nd, J, J2d, IDm(nsd,nsd), C(nsd,nsd),
-     2   Ci(nsd,nsd), Sb(nsd,nsd), r1
-
-      nd  = REAL(nsd, KIND=RKIND)
-      J   = MAT_DET(F, nsd)
-      J2d = J**(-2._RKIND/nd)
-
-      IDm = MAT_ID(nsd)
-      C   = MATMUL(TRANSPOSE(F), F)
-      Ci  = MAT_INV(C, nsd)
-
-      Sb  = Tact * MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
-
-      r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
-      S   = S + J2d*Sb - r1*Ci
-
-      RETURN
-      END SUBROUTINE ACTVSTRSdev
 !####################################################################
 !     Compute active component of deformation gradient tensor for
 !     electromechanics coupling based on active strain formulation

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -92,61 +92,6 @@
          REAL(KIND=RKIND), ALLOCATABLE :: xi(:)
       END TYPE bsType
 
-      TYPE stModelType
-!        Type of constitutive model (volumetric) for struct/FSI
-         INTEGER(KIND=IKIND) :: volType = stVol_NA
-!        Penalty parameter
-         REAL(KIND=RKIND) :: Kpen = 0._RKIND
-!        Type of constitutive model (isochoric) for struct/FSI
-         INTEGER(KIND=IKIND) :: isoType = stIso_NA
-!        Parameters specific to the constitutive model (isochoric)
-!        NeoHookean model (C10 = mu/2)
-         REAL(KIND=RKIND) :: C10 = 0._RKIND
-!        Mooney-Rivlin model (C10, C01)
-         REAL(KIND=RKIND) :: C01 = 0._RKIND
-!        Holzapfel model(a, b, aff, bff, ass, bss, afs, bfs, kap)
-         REAL(KIND=RKIND) :: a   = 0._RKIND
-         REAL(KIND=RKIND) :: b   = 0._RKIND
-         REAL(KIND=RKIND) :: aff = 0._RKIND
-         REAL(KIND=RKIND) :: bff = 0._RKIND
-         REAL(KIND=RKIND) :: ass = 0._RKIND
-         REAL(KIND=RKIND) :: bss = 0._RKIND
-         REAL(KIND=RKIND) :: afs = 0._RKIND
-         REAL(KIND=RKIND) :: bfs = 0._RKIND
-!        Collagen fiber dispersion parameter (Holzapfel model)
-         REAL(KIND=RKIND) :: kap = 0._RKIND
-!        Fiber reinforcement stress
-         REAL(KIND=RKIND) :: Tf
-      END TYPE stModelType
-
-      TYPE viscModelType
-!        Type of constitutive model for fluid viscosity
-         INTEGER(KIND=IKIND) :: viscType = viscType_NA
-!        Limiting zero shear-rate viscosity value
-         REAL(KIND=RKIND) :: mu_o = 0._RKIND
-!        Limiting high shear-rate viscosity (asymptotic) value
-         REAL(KIND=RKIND) :: mu_i = 0._RKIND
-!        Strain-rate tensor multiplier
-         REAL(KIND=RKIND) :: lam = 0._RKIND
-!        Strain-rate tensor exponent
-         REAL(KIND=RKIND) :: a = 0._RKIND
-!        Power-law exponent
-         REAL(KIND=RKIND) :: n = 0._RKIND
-      END TYPE viscModelType
-
-      TYPE rcrType
-!        Proximal resistance
-         REAL(KIND=RKIND) :: Rp = 0._RKIND
-!        Capacitance
-         REAL(KIND=RKIND) :: C  = 0._RKIND
-!        Distance resistance
-         REAL(KIND=RKIND) :: Rd = 0._RKIND
-!        Distal pressure
-         REAL(KIND=RKIND) :: Pd = 0._RKIND
-!        Initial value
-         REAL(KIND=RKIND) :: Xo = 0._RKIND
-      END TYPE rcrType
-
 !     Fourier coefficients that are used to specify unsteady BCs
       TYPE fcType
 !        If this is a ramp function
@@ -182,6 +127,19 @@
 !     Displacements at each direction, location, and time point
          REAL(KIND=RKIND), ALLOCATABLE :: d(:,:,:)
       END TYPE MBType
+
+      TYPE rcrType
+!        Proximal resistance
+         REAL(KIND=RKIND) :: Rp = 0._RKIND
+!        Capacitance
+         REAL(KIND=RKIND) :: C  = 0._RKIND
+!        Distance resistance
+         REAL(KIND=RKIND) :: Rd = 0._RKIND
+!        Distal pressure
+         REAL(KIND=RKIND) :: Pd = 0._RKIND
+!        Initial value
+         REAL(KIND=RKIND) :: Xo = 0._RKIND
+      END TYPE rcrType
 
 !     Boundary condition data type
       TYPE bcType
@@ -246,8 +204,62 @@
          TYPE(MBType), ALLOCATABLE :: bm
       END TYPE bfType
 
+!     Fiber stress type
+      TYPE fibStrsType
+!        Type of fiber stress
+         INTEGER(KIND=IKIND) :: fType = 0
+!        Constant steady value
+         REAL(KIND=8) :: g = 0._RKIND
+!        Unsteady time-dependent values
+         TYPE(fcType) :: gt
+      END TYPE fibStrsType
+
+!     Structural domain type
+      TYPE stModelType
+!        Type of constitutive model (volumetric) for struct/FSI
+         INTEGER(KIND=IKIND) :: volType = stVol_NA
+!        Penalty parameter
+         REAL(KIND=RKIND) :: Kpen = 0._RKIND
+!        Type of constitutive model (isochoric) for struct/FSI
+         INTEGER(KIND=IKIND) :: isoType = stIso_NA
+!        Parameters specific to the constitutive model (isochoric)
+!        NeoHookean model (C10 = mu/2)
+         REAL(KIND=RKIND) :: C10 = 0._RKIND
+!        Mooney-Rivlin model (C10, C01)
+         REAL(KIND=RKIND) :: C01 = 0._RKIND
+!        Holzapfel model(a, b, aff, bff, ass, bss, afs, bfs, kap)
+         REAL(KIND=RKIND) :: a   = 0._RKIND
+         REAL(KIND=RKIND) :: b   = 0._RKIND
+         REAL(KIND=RKIND) :: aff = 0._RKIND
+         REAL(KIND=RKIND) :: bff = 0._RKIND
+         REAL(KIND=RKIND) :: ass = 0._RKIND
+         REAL(KIND=RKIND) :: bss = 0._RKIND
+         REAL(KIND=RKIND) :: afs = 0._RKIND
+         REAL(KIND=RKIND) :: bfs = 0._RKIND
+!        Collagen fiber dispersion parameter (Holzapfel model)
+         REAL(KIND=RKIND) :: kap = 0._RKIND
+!        Fiber reinforcement stress
+         TYPE(fibStrsType) :: Tf
+      END TYPE stModelType
+
+!     Fluid viscosity model type
+      TYPE viscModelType
+!        Type of constitutive model for fluid viscosity
+         INTEGER(KIND=IKIND) :: viscType = viscType_NA
+!        Limiting zero shear-rate viscosity value
+         REAL(KIND=RKIND) :: mu_o = 0._RKIND
+!        Limiting high shear-rate viscosity (asymptotic) value
+         REAL(KIND=RKIND) :: mu_i = 0._RKIND
+!        Strain-rate tensor multiplier
+         REAL(KIND=RKIND) :: lam = 0._RKIND
+!        Strain-rate tensor exponent
+         REAL(KIND=RKIND) :: a = 0._RKIND
+!        Power-law exponent
+         REAL(KIND=RKIND) :: n = 0._RKIND
+      END TYPE viscModelType
+
 !     Domain type is to keep track with element belong to which domain
-!     and also different hysical quantities
+!     and also different physical quantities
       TYPE dmnType
 !        The domain ID. Default includes entire domain
          INTEGER(KIND=IKIND) :: Id = -1

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -115,6 +115,8 @@
          REAL(KIND=RKIND) :: bfs = 0._RKIND
 !        Collagen fiber dispersion parameter (Holzapfel model)
          REAL(KIND=RKIND) :: kap = 0._RKIND
+!        Fiber reinforcement stress
+         REAL(KIND=RKIND) :: Tf
       END TYPE stModelType
 
       TYPE viscModelType

--- a/Code/Source/svFSI/POST.f
+++ b/Code/Source/svFSI/POST.f
@@ -1355,7 +1355,7 @@
             std = TRIM(sepLine)
             std = " "//CLR("<< BIN ---> VTK >>")//"    "//TRIM(fName)
             CALL INITFROMBIN(fName, rtmp)
-            CALL WRITEVTUS(Ao, Yo, Do)
+            CALL WRITEVTUS(Ao, Yo, Do, .FALSE.)
          END IF
       END DO
       std = TRIM(sepLine)

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -2477,6 +2477,11 @@ c     2         "can be applied for Neumann boundaries only"
          err = "Undefined constitutive model used"
       END SELECT
 
+!     Fiber reinforcement stress
+      lDmn%stM%Tf = 0._RKIND
+      lPtr => lPD%get(rtmp, "Fiber reinforcement stress")
+      IF (ASSOCIATED(lPtr)) lDmn%stM%Tf = rtmp
+
 !     Look for dilational penalty model. HGO uses quadratic penalty model
       lPtr => lPD%get(ctmp, "Dilational penalty model")
       IF (.NOT.ASSOCIATED(lPtr)) wrn =

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -2374,10 +2374,13 @@ c     2         "can be applied for Neumann boundaries only"
       TYPE(dmnType), INTENT(INOUT) :: lDmn
       TYPE(listType), INTENT(INOUT) :: lPD
 
-      LOGICAL incompFlag
+      LOGICAL incompFlag, ltmp
+      INTEGER(KIND=IKIND) fid, i, j
       REAL(KIND=RKIND) :: E, nu, lam, mu, kap, rtmp
       CHARACTER(LEN=stdL) ctmp
-      TYPE(listType), POINTER :: lPtr, lSt
+
+      TYPE(listType), POINTER :: lPtr, lSt, lFib
+      TYPE(fileType) fTmp
 
 !     Domain properties: elasticity modulus, poisson ratio
       E   = lDmn%prop(elasticity_modulus)
@@ -2478,9 +2481,40 @@ c     2         "can be applied for Neumann boundaries only"
       END SELECT
 
 !     Fiber reinforcement stress
-      lDmn%stM%Tf = 0._RKIND
-      lPtr => lPD%get(rtmp, "Fiber reinforcement stress")
-      IF (ASSOCIATED(lPtr)) lDmn%stM%Tf = rtmp
+      lFib => lPD%get(ctmp, "Fiber reinforcement stress")
+      IF (ASSOCIATED(lFib)) THEN
+         CALL TO_LOWER(ctmp)
+         SELECT CASE (TRIM(ctmp))
+         CASE ("steady")
+            lDmn%stM%Tf%fType = IBSET(lDmn%stM%Tf%fType, bType_std)
+            lPtr => lFib%get(lDmn%stM%Tf%g, "Value")
+
+         CASE ("unsteady")
+            lDmn%stM%Tf%fType = IBSET(lDmn%stM%Tf%fType, bType_ustd)
+            lPtr => lFib%get(fTmp, "Temporal values file path")
+            lTmp = .FALSE.
+            lPtr => lFib%get(ltmp, "Ramp function")
+            lDmn%stM%Tf%gt%lrmp = lTmp
+            fid = fTmp%open()
+            READ(fid,*) i, j
+            IF (i .LT. 2) THEN
+               std = "Enter nPts nFCoef; nPts*(t Q)"
+               err = "Wrong format in: "//fTmp%fname
+            END IF
+            lDmn%stM%Tf%gt%d = 1
+            lDmn%stM%Tf%gt%n = j
+            IF (lDmn%stM%Tf%gt%lrmp) lDmn%stM%Tf%gt%n = 1
+            ALLOCATE(lDmn%stM%Tf%gt%qi(lDmn%stM%Tf%gt%d),
+     2         lDmn%stM%Tf%gt%qs(lDmn%stM%Tf%gt%d),
+     3         lDmn%stM%Tf%gt%r(lDmn%stM%Tf%gt%d,lDmn%stM%Tf%gt%n),
+     4         lDmn%stM%Tf%gt%i(lDmn%stM%Tf%gt%d,lDmn%stM%Tf%gt%n))
+            CALL FFT(fid, i, lDmn%stM%Tf%gt)
+            CLOSE(fid)
+
+         CASE DEFAULT
+            err = "Undefined type of fiber reinforcement stress"
+         END SELECT
+      END IF
 
 !     Look for dilational penalty model. HGO uses quadratic penalty model
       lPtr => lPD%get(ctmp, "Dilational penalty model")

--- a/Code/Source/svFSI/STRUCT.f
+++ b/Code/Source/svFSI/STRUCT.f
@@ -222,9 +222,6 @@
       pSl(6) = S(3,1)
       S = S + S0
 
-!     Active stress - electromechanics
-      IF (cem%aStress) CALL ACTVSTRESS(ya_g, nFn, fN, S)
-
 !     1st Piola-Kirchhoff tensor (P)
       P = MATMUL(F, S)
 
@@ -386,9 +383,6 @@
       pSl(2) = S(2,2)
       pSl(3) = S(1,2)
       S = S + S0
-
-!     Active stress - electromechanics
-      IF (cem%aStress) CALL ACTVSTRESS(ya_g, nFn, fN, S)
 
 !     1st Piola-Kirchhoff tensor (P)
       P = MATMUL(F, S)

--- a/Code/Source/svFSI/USTRUCT.f
+++ b/Code/Source/svFSI/USTRUCT.f
@@ -278,9 +278,6 @@
          tauC = 0._RKIND
       END IF
 
-!     Active stress from electromechanics
-      IF (cem%aStress) CALL ACTVSTRSdev(ya_g, F, nFn, fN, Siso)
-
 !     Deviatoric 1st Piola-Kirchhoff tensor (P)
       Pdev = MATMUL(F, Siso)
 
@@ -598,9 +595,6 @@
          tauM = 0._RKIND
          tauC = 0._RKIND
       END IF
-
-!     Active stress from electromechanics
-      IF (cem%aStress) CALL ACTVSTRSdev(ya_g, F, nFn, fN, Siso)
 
 !     Deviatoric 1st Piola-Kirchhoff tensor (P)
       Pdev = MATMUL(F, Siso)

--- a/Code/Source/svFSI/VTKXML.f
+++ b/Code/Source/svFSI/VTKXML.f
@@ -182,7 +182,7 @@
             l = eq(iEq)%output(iOut)%l
             s = eq(iEq)%s + eq(iEq)%output(iOut)%o
             e = s + l - 1
-            varName = eq(iEq)%sym//"_"//TRIM(eq(iEq)%output(iOut)%name)
+            varName = TRIM(eq(iEq)%output(iOut)%name)
 
             oGrp = eq(iEq)%output(iOut)%grp
             SELECT CASE(oGrp)
@@ -407,13 +407,14 @@
       RETURN
       END SUBROUTINE WRITEVTP
 !--------------------------------------------------------------------
-      SUBROUTINE WRITEVTUS(lA, lY, lD)
+      SUBROUTINE WRITEVTUS(lA, lY, lD, lAve)
       USE COMMOD
       USE ALLFUN
       USE vtkXMLMod
       IMPLICIT NONE
       REAL(KIND=RKIND), INTENT(IN) :: lA(tDof,tnNo), lY(tDof,tnNo),
      2   lD(tDof,tnNo)
+      LOGICAL, INTENT(IN) :: lAve
 
       LOGICAL :: lIbl, lD0
       INTEGER(KIND=IKIND) :: iStat, iEq, iOut, iM, a, e, Ac, Ec, nNo,
@@ -578,8 +579,8 @@
                      is   = outS(cOut)
                      ie   = is + l - 1
                      outS(cOut+1)   = ie + 1
-                     outNames(cOut) = eq(iEq)%sym//"_"//
-     2                  TRIM(eq(iEq)%output(iOut)%name)//STR(iFn)
+                     outNames(cOut) = TRIM(eq(iEq)%output(iOut)%name)//
+     2                  STR(iFn)
                      DO a=1, msh(iM)%nNo
                         d(iM)%x(is:ie,a) =
      2                     tmpV((iFn-1)*nsd+1:iFn*nsd,a)
@@ -701,7 +702,7 @@
       ALLOCATE(tmpV(maxnsd, nNo))
 
 !     Writing to vtu file (master only)
-      IF (cTS .GE. 1000) THEN
+      IF (cTS.GE.1000 .OR. lAve) THEN
          fName = STR(cTS)
       ELSE
          WRITE(fName,'(I3.3)') cTS
@@ -1301,7 +1302,7 @@
       fName = saveName
       saveName = TRIM(saveName)//"_ave_"//STR(fTS)//"_"//
      2   STR(saveIncr)
-      CALL WRITEVTUS(Ag, Yg, Dg)
+      CALL WRITEVTUS(Ag, Yg, Dg, .TRUE.)
       saveName = fName
 
       RETURN


### PR DESCRIPTION
Major changes in this pull request include: 
1. Ability to add fiber-reinforced stress that could be used for cardiac mechanics. This stress can be specified as a steady value or as unsteady data read from a file.
2. A bug fix related to computing averaged quantities. See the corresponding commit for more info.