### PR TITLE
added heaviside approximation function

### DIFF
--- a/Code/CMake/SimVascularOptions.cmake
+++ b/Code/CMake/SimVascularOptions.cmake
@@ -59,7 +59,7 @@ option(SV_USE_NOTIMER "Use notimer" ON)
 option(SV_USE_METIS_SVFSI "Use metis_svfsi Library" ON)
 option(SV_USE_PARMETIS_SVFSI "Use parmetis_svfsi Library" ON)
 option(SV_USE_TETGEN "Use tetgen Library" ON)
-option(SV_USE_TRILINOS "Use Trilinos Library with svFSI" OFF)
+option(SV_USE_TRILINOS "Use Trilinos Library with svFSI" ON)
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------

--- a/Code/Source/svFSI/ALLFUN.f
+++ b/Code/Source/svFSI/ALLFUN.f
@@ -1296,6 +1296,7 @@
       lDmn%stM%bss     = 0._RKIND
       lDmn%stM%afs     = 0._RKIND
       lDmn%stM%bfs     = 0._RKIND
+      lDmn%stM%kexp	= 0._RKIND
 
       lDmn%stM%Tf%g     = 0._RKIND
       lDmn%stM%Tf%fType = 0

--- a/Code/Source/svFSI/DISTRIBUTE.f
+++ b/Code/Source/svFSI/DISTRIBUTE.f
@@ -1051,6 +1051,7 @@
       CALL cm%bcast(lStM%afs)
       CALL cm%bcast(lStM%bfs)
       CALL cm%bcast(lStM%kap)
+      CALL cm%bcast(lStM%kexp)
 
 !     Distribute fiber stress
       CALL cm%bcast(lStM%Tf%fType)

--- a/Code/Source/svFSI/MATMODELS.f
+++ b/Code/Source/svFSI/MATMODELS.f
@@ -56,7 +56,7 @@
 !     Guccione
       REAL(KIND=RKIND) :: QQ, Rm(nsd,nsd), Es(nsd,nsd), RmRm(nsd,nsd,6)
 !     HGO/HO model
-      REAL(KIND=RKIND) :: Eff, Ess, Efs, kap, Hff(nsd,nsd),
+      REAL(KIND=RKIND) :: Eff, Ess, chi, Efs, kap, Hff(nsd,nsd),
      4   Hss(nsd,nsd), Hfs(nsd,nsd)
 !     Active strain for electromechanics
       REAL(KIND=RKIND) :: Fe(nsd,nsd), Fa(nsd,nsd), Fai(nsd,nsd)
@@ -312,12 +312,14 @@
      2      EXP(stM%bfs*Efs)
          CCb  = g1 * TEN_DYADPROD(IDm, IDm, nsd) +
      2          g2 * TEN_DYADPROD(Hfs, Hfs, nsd)
+     	 
+     	 chi = 1._RKIND / (1._RKIND + EXP(-stM%kexp*Eff))
 
-         IF (Eff .GT. 0._RKIND) THEN
+!         IF (Eff .GT. 0._RKIND) THEN
 !            Fiber reinforcement/active stress
              g1  = Tfa
 
-             g1  = g1 + 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff)
+             g1  = g1 + 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff) * chi
              Hff = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
              Sb  = Sb + g1*Hff
 
@@ -325,10 +327,10 @@
              g1  = 4._RKIND*J4d*stM%aff*(1._RKIND +
      2          2._RKIND*stM%bff*Eff)*EXP(stM%bff*Eff)
              CCb = CCb + g1*TEN_DYADPROD(Hff, Hff, nsd)
-         END IF
+!         END IF
 
-         IF (Ess .GT. 0._RKIND) THEN
-             g2  = 2._RKIND * stM%ass * Ess * EXP(stM%bss*Ess*Ess)
+!         IF (Ess .GT. 0._RKIND) THEN
+             g2  = 2._RKIND * stM%ass * Ess * EXP(stM%bss*Ess*Ess) * chi
              Hss = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
              Sb  = Sb + g2*Hss
 
@@ -336,7 +338,7 @@
              g2  = 4._RKIND*J4d*stM%ass*(1._RKIND +
      2          2._RKIND*stM%bss*Ess)*EXP(stM%bss*Ess)
              CCb = CCb + g2*TEN_DYADPROD(Hss, Hss, nsd)
-         END IF
+!         END IF
 
          r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
          S   = J2d*Sb - r1*Ci

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -227,7 +227,7 @@
          REAL(KIND=RKIND) :: C10 = 0._RKIND
 !        Mooney-Rivlin model (C10, C01)
          REAL(KIND=RKIND) :: C01 = 0._RKIND
-!        Holzapfel model(a, b, aff, bff, ass, bss, afs, bfs, kap)
+!        Holzapfel model(a, b, aff, bff, ass, bss, afs, bfs, kap, kexp)
          REAL(KIND=RKIND) :: a   = 0._RKIND
          REAL(KIND=RKIND) :: b   = 0._RKIND
          REAL(KIND=RKIND) :: aff = 0._RKIND
@@ -236,6 +236,7 @@
          REAL(KIND=RKIND) :: bss = 0._RKIND
          REAL(KIND=RKIND) :: afs = 0._RKIND
          REAL(KIND=RKIND) :: bfs = 0._RKIND
+         REAL(KIND=RKIND) :: kexp = 0._RKIND
 !        Collagen fiber dispersion parameter (Holzapfel model)
          REAL(KIND=RKIND) :: kap = 0._RKIND
 !        Fiber reinforcement stress

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -2482,6 +2482,7 @@ c     2         "can be applied for Neumann boundaries only"
          lPtr => lSt%get(lDmn%stM%bss, "b4s")
          lPtr => lSt%get(lDmn%stM%afs, "afs")
          lPtr => lSt%get(lDmn%stM%bfs, "bfs")
+         lPtr => lSt%get(lDmn%stM%kexp, "k")
 
       CASE DEFAULT
          err = "Undefined constitutive model used"


### PR DESCRIPTION
This is a branch used for a benchmark problem.

A new material parameter k was added to the constitutive model HO. It is in the equation of chi(x)=1/(1+exp(-k(x-1))) which is used to approximate the heaviside function in a "softer" way to calculate only the fiber stress in tension instead of the method used in the original codes which used a hard if-else function.

A higher k corresponds to a steeper approximation of the heaviside function.