### PR TITLE
Add Intel oneAPI Toolkits build support.

### DIFF
--- a/Code/Source/svFSI/ALLFUN.f
+++ b/Code/Source/svFSI/ALLFUN.f
@@ -1560,9 +1560,15 @@
          br = b(ml+1:m)
       END IF
       nl = NINT(REAL(n, KIND=RKIND)*SUM(bl)/sb, KIND=IKIND)
-      IF (nl .EQ. 0) nl = 1
-      IF (nl .EQ. n) nl = n - 1
-      nr = n - nl
+      IF (nl .EQ. 0) THEN
+         nl = 1
+         nr = n - 1
+      ELSE IF (nl .EQ. n) THEN
+         nl = n - 1
+         nr = 1
+      ELSE
+         nr = n - nl
+      END IF
       ALLOCATE (Al(ml,nl), Ar(mr,nr))
 
       CALL SPLITJOBS(ml,nl,Al,bl)

--- a/Code/Source/svFSI/CMakeLists.txt
+++ b/Code/Source/svFSI/CMakeLists.txt
@@ -41,9 +41,12 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   # set(CMAKE_Fortran_FLAGS "-O0")
   # set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -pthread -std=legacy")
   # set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -Wall -Wconversion -Wline-truncation -pedantic -fimplicit-none -fbacktrace -fbounds-check -p -fcheck=all -ffpe-trap=invalid,zero,overflow,underflow")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  set(CMAKE_Fortran_FLAGS "-O3 -march=native")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -pthread")
 else()
   # nothing for now
-  # may need to set for intel compiler or others
+  # may need to set for other compilers
 endif()
 
 # Find Trilinos package if requested
@@ -101,10 +104,6 @@ if(WITH_TRILINOS)
   ADD_DEFINITIONS(-DWITH_TRILINOS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
-
-# svFSI requires LAPACK
-find_package(BLAS REQUIRED)
-find_package(LAPACK REQUIRED)
 
 
 set(FSRCS TYPEMOD.f
@@ -198,14 +197,22 @@ target_link_libraries(${SV_SVFSI_EXE}
   ${GLOBAL_LIBRARIES}
   ${INTELRUNTIME_LIBRARIES}
   ${ZLIB_LIBRARY}
-  ${BLAS_LIBRARIES}
-  ${LAPACK_LIBRARIES}
   ${METIS_SVFSI_LIBRARY_NAME}
   ${PARMETIS_SVFSI_LIBRARY_NAME}
   ${TETGEN_LIBRARY_NAME}
   ${SV_MPI_Fortran_LIBRARIES}
   ${SV_LIB_SVFSILS_NAME}${SV_MPI_NAME_EXT}
   )
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+  # svFSI requires LAPACK
+  find_package(BLAS REQUIRED)
+  find_package(LAPACK REQUIRED)
+  target_link_libraries(${SV_SVFSI_EXE} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  set_target_properties(svFSI PROPERTIES LINKER_LANGUAGE Fortran)
+  target_link_libraries(${SV_SVFSI_EXE} -mkl)
+endif()  
 
 # extra MPI libraries only if there are not set to NOT_FOUND or other null
 if(SV_MPI_EXTRA_LIBRARY)

--- a/Code/Source/svFSILS/CMakeLists.txt
+++ b/Code/Source/svFSILS/CMakeLists.txt
@@ -8,9 +8,12 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   # set(CMAKE_Fortran_FLAGS "-O0")
   # set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -pthread -std=legacy")
   # set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -Wall -Wconversion -Wline-truncation -pedantic -fimplicit-none -fbacktrace -fbounds-check -p -fcheck=all -ffpe-trap=invalid,zero,overflow,underflow")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+  set(CMAKE_Fortran_FLAGS "-O3 -march=native")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -pthread")
 else()
   # nothing for now
-  # may need to reset for intel compiler or others
+  # may need to set for other compilers
 endif()
 
 set(lib ${SV_LIB_SVFSILS_NAME}${SV_MPI_NAME_EXT})

--- a/INSTALL-DEPS.md
+++ b/INSTALL-DEPS.md
@@ -1,7 +1,27 @@
 
 This file describes a general procedure to install `svFSI` dependencies. While most dependencies provided below are built from source, users are encouraged to use package managers such as `apt` for Ubuntu and `brew` for Mac OSX when available. Users may modify the parameters according to the local module and compiler environment. Please note that the below procedures are primarily intended for moderate to advanced Linux users only. Others are encouraged to use precompiled binaries at [SimTK](https://simtk.org/frs/index.php?group_id=188) or the `Quick Build` procedure outlined in the README.md file.
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
+## Intel oneAPI Toolkits
+
+Intel has release its next-gen software development suite, oneAPI, free of charge. This suite provides comprehensive compiler support for Linux, Windows and limited support for macOS. To build `svFSI` with Intel oneAPI compilers, the following two toolkits should be installed:
+[Intel oneAPI Base Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/base-toolkit.html#gs.cld9rl) and [Intel oneAPI HPC Toolkit](https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html#gs.cldcfd). Detailed installation instructions are provided on the download page of each toolkit.
+
+Intel oneAPI Base Toolkit provides development tools for general computing and consists of over a dozen components. Users only need to install selected few in order to build `svFSI`. We recommend the following:
+- Intel oneAPI Collective Communications Library
+- Intel oneAPI DPC++/C++ Compiler
+- Intel oneAPI DPC++ Library
+- Intel oneAPI Math Kernel Library
+- Intel oneAPI Threading Building Blocks
+- Intel Distribution for GDB
+- Intel DPC++ Compatibility Tool
+- Intel VTune Profiler
+
+Intel oneAPI HPC Toolkit complements the Base Toolkit and provides necessary components for high-performance computing, such as Fortran compiler and MPI library. We recommend install all of the components. Please note that there is no Intel MPI library for macOS as of version 2021.3.0.
+
+<hr style="border:2px solid gray"> </hr>
+
 ## Curses CMake
 
 Before installing cmake, install libncurses5-dev from apt as,
@@ -12,7 +32,8 @@ sudo apt-get install libncurses5-dev
 
 to get ccmake installed
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## CMAKE 3.20.5
 
 Downloaded cmake version 3.20.5 from,
@@ -32,7 +53,8 @@ make
 sudo make install
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## MPICH
 
 Downloaded mpich version 3.4.2 from,
@@ -51,7 +73,8 @@ make
 sudo make install
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## OpenMPI
 
 Downloaded openmpi version 4.1.1 from,
@@ -70,7 +93,8 @@ make
 sudo make install
 ```
 
-# =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## LAPACK
 
 Downloaded lapack version 3.9.1 from,
@@ -126,7 +150,8 @@ sudo ln -sf /opt/netlib/lapack/3.9.1/static/liblapack.a  /usr/local/lib
 sudo ln -sf /opt/netlib/lapack/3.9.1/static/libblas.a  /usr/local/lib
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## Boost
 
 Boost installed version: boost_1_66_0.tar.gz
@@ -141,7 +166,8 @@ cd boost_1_66_0
 sudo ./b2 install
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## HDF5
 
 HDF5 installed version: hdf5-1.10.4.tar.gz
@@ -159,7 +185,8 @@ make
 sudo make install
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## HYPRE
 
 HYPRE installed version: hypre-2.22.0.tar.gz
@@ -175,7 +202,8 @@ cd hypre-2.22.0/src
 sudo make install
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## MUMPS
 
 MUMPS installed version: MUMPS_5.4.0.tar.gz
@@ -295,7 +323,8 @@ Copy `include`, `lib`, and `examples` to the destination folder.
 sudo cp -r include/ lib/ examples/ /opt/mumps/5.4.0
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## Trilinos
 
 Trilinos installed version: Trilinos-trilinos-release-13-0-1.tar.gz
@@ -312,13 +341,15 @@ mkdir build_mpich
 cd build_mpich
 ```
 
-### Compiler flags for performance
+Compiler flags for performance
 
+```bash
 CXXFLAGS = -O3 -DNDEBUG -march=native
 CFLAGS = -O3 -DNDEBUG -march=native
 FCFLAGS = -O3 -march=native
+```
 
-### CMake Configuration:
+CMake configuration for GNU compilers:
 
 ```bash
     cmake                                            \
@@ -360,6 +391,41 @@ FCFLAGS = -O3 -march=native
     ../
 ```
 
+Minimalist CMake configuration for Intel oneAPI Toolkits
+```bash
+#!/bin/bash
+
+INTEL_MPI_DIR=/opt/pkg/intel/oneapi/mpi/2021.3.0
+INTEL_MKL_DIR=/opt/pkg/intel/oneapi/mkl/2021.3.0
+
+cmake \
+    -DCMAKE_INSTALL_PREFIX:PATH=/opt/pkg/trilinos/13.0.1_intel \
+    -D TPL_ENABLE_MPI=ON \
+    -D MPI_BASE_DIR="${INTEL_MPI_DIR}" \
+    -D TPL_ENABLE_MKL:BOOL=ON \
+    -D MKL_LIBRARY_DIRS:FILEPATH="${INTEL_MKL_DIR}/lib/intel64" \
+    -D MKL_INCLUDE_DIRS:FILEPATH="${INTEL_MKL_DIR}/include" \
+    -D Trilinos_ENABLE_OpenMP=OFF \
+    -DTPL_ENABLE_BLAS:BOOL=ON \
+    -D BLAS_LIBRARY_DIRS:FILEPATH="${INTEL_MKL_DIR}/lib/intel64" \
+    -D BLAS_LIBRARY_NAMES:STRING="mkl_intel_lp64;mkl_sequential;mkl_core" \
+    -DTPL_ENABLE_LAPACK:BOOL=ON \
+    -D LAPACK_LIBRARY_DIRS:FILEPATH="${INTEL_MKL_DIR}/lib/intel64" \
+    -D LAPACK_LIBRARY_NAMES:STRING="mkl_intel_lp64;mkl_sequential;mkl_core" \
+    -DTrilinos_ENABLE_FLOAT=ON \
+    -DTrilinos_ENABLE_TESTS:BOOL=ON \
+    -DTrilinos_ENABLE_Epetra:BOOL=ON \
+    -DTrilinos_ENABLE_AztecOO:BOOL=ON \
+    -DTrilinos_ENABLE_Amesos:BOOL= ON \
+    -DTrilinos_ENABLE_ML:Bool=ON \
+    -DTrilinos_ENABLE_MueLu:Bool=ON \
+    -DTrilinos_ENABLE_Ifpack:BOOL=ON \
+    -DCMAKE_BUILD_TYPE=RELEASE \
+    -D BUILD_SHARED_LIBS=ON \
+    ../
+```
+Here, `BLAS_LIBRARY_NAMES` and `LAPACK_LIBRARY_NAMES` are platform/architecture specific. Please consult [Intel Link Line Advisor](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl/link-line-advisor.html).
+
 Finally, compile and install
 
 ```bash
@@ -367,5 +433,6 @@ make -j <num_processes>
 sudo make install
 ```
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,8 @@
 
 Below are the instructions to build svFSI on Ubuntu and MacOS.
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## svFSI on Ubuntu 18.04
 
 ### Download svFSI
@@ -35,21 +36,36 @@ cd build
 
 This structure creates a separate directory for `svFSI` git repository `src` and a separate `build` folder where `svFSI` is compiled.
 
-### Build environment:
+### Build
 
-Ubuntu 18.04
-gcc/g++/gfortran 7.5.0
-mpich 3.4.0
-cmake 3.20.5
+Tested environment: Ubuntu 18.04,
+gcc/g++/gfortran 7.5.0,
+mpich 3.4.0,
+cmake 3.20.5,
 lapack/blas 3.9.1
+   ```bash
+   ccmake ..
+   ```
 
-Trilinos & its dependencies:
-    boost 1.66.0
-    hdf5 1.10.4
-    hypre 2.22.0
-    trilinos 13.01
+Or
+
+Tested environment: Ubuntu 18.04, Intel oneAPI Base Toolkit 2021.3.0, Intel oneAPI HPC Toolkit 2021.3.0
+   ```bash
+   ccmake \
+​      -DCMAKE_C_COMPILER:PATH=${ONEAPI_ROOT}/compiler/2021.3.0/linux/bin/intel64/icc \
+​      -DCMAKE_CXX_COMPILER:PATH=${ONEAPI_ROOT}/compiler/2021.3.0/linux/bin/intel64/icpc \
+​      -DCMAKE_Fortran_COMPILER:PATH=${ONEAPI_ROOT}/compiler/2021.3.0/linux/bin/intel64/ifort ..
+   ```
+   Here `ONEAPI_ROOT` is an environment variable automatically set by Intel oneAPI.
 
 ### Build with Trilinos (optional)
+
+Tested environment:
+Trilinos & its dependencies(
+    boost 1.66.0,
+    hdf5 1.10.4,
+    hypre 2.22.0,
+    trilinos 13.01)
 
 To compile `svFSI` with Trilinos, the following changes need to be made to the file, `Code/CMake/SimVascularOptions.cmake`
 
@@ -94,7 +110,7 @@ and for the linear solver `svFSILS`, modify `CMAKE_Fortran_FLAGS` in the file `C
 
 Note that the option `std=legacy` is used for more recent versions of gcc (version >= 10).
 
-### Additional CMake Settings
+### Additional CMake settings
 
 Occasionally, C and CXX compilers may be wrongly identified by the CMake system used for `svFSI`. By default, the C compiler used is `/usr/bin/cc` and the CXX compiler is `/usr/bin/c++`. However, depending on the modules loaded on HPC or one's local compiler environment, these may not be pointing to the desired compilers such as those wrapped by mpicc or mpicxx.
 
@@ -104,7 +120,7 @@ In such situations, we recommend providing the correct C and CXX compilers using
 ccmake -DCMAKE_C_COMPILER:PATH=/usr/bin/gcc -DCMAKE_CXX_COMPILER:PATH=/usr/bin/g++  <path_to_svFSI_source>
 ```
 
-### CMake Configuration:
+### CMake configuration:
 
 An example CMake command for compiling `svFSI` with Trilinos is given below:
 
@@ -135,7 +151,8 @@ ldd svFSI-build/bin/svFSI
 ```
 The code will not run if any library is not found. A wrapper script is also available in `svFSI-build/mysvFSI` which sets environmental variables.
 
-## =================================================================
+<hr style="border:2px solid gray"> </hr>
+
 ## `svFSI` on Mac OSX
 
 Follow the steps below to install `svFSI` on Mac.
@@ -219,4 +236,4 @@ cd build
 ccmake ../
 make
 ```
-## =================================================================
+<hr style="border:2px solid gray"> </hr>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following packages are required to build and use `svFSI`.
    - blas & lapack
    - trilinos (optional)
 
-On Ubuntu, most of the dependencies can be downloaded using `apt-get`. On Mac OSX, the dependencies may be installed using `brew`.
+On Ubuntu, most of the dependencies can be installed using `apt install`. On macOS, the dependencies may be installed using `brew`. Apart from GNU compilers, `svFSI` can also be built with Intel oneAPI Toolkits. For more details, please refer to [`INSTALL.md`](./INSTALL.md#Build) and [`INSTALL-DEPS.md`](./INSTALL-DEPS.md#intel-oneapi-toolkitsd).
 
 ## Quick Build
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-`svFSI` is a  multi-physics finite element solver designed for computational modeling of the cardiovascular system. Some of the unique capabilities of `svFSI` include modeling cardiac electrophysiology, biological tissue mechanics, blood flow, and large deformation fluid-structure interaction (FSI). `svFSI` also offers a wide choice of boundary conditions for performing patient-specific modeling of cardiovascular biomechanics. The code is parallelized using message-passing-interface (MPI) and offers multiple options to choose a linear solver and preconditioner. `svFSI` can be used as part of the [SimVascular](https://simvascular.github.io) software or can be used as a stand-alone solver. The solver is released under the MIT License open source initiative.
+`svFSI` is a  multi-physics finite element solver designed for computational modeling of the cardiovascular system. Some of the unique capabilities of `svFSI` include modeling cardiac electrophysiology, biological tissue mechanics, blood flow, and large deformation fluid-structure interaction (FSI). `svFSI` also offers a wide choice of boundary conditions for performing patient-specific modeling of cardiovascular biomechanics. The code is parallelized using message-passing-interface (MPI) and offers multiple options to choose a linear solver and preconditioner. `svFSI` can be used as part of the [SimVascular](https://simvascular.github.io) software or can be used as a stand-alone solver.
 
 ## Dependence
 
@@ -112,9 +112,6 @@ More details can be found here:
 - Cardiac electrophysiology modeling: http://simvascular.github.io/docsSimCardio.html#cep-modeling
 - Cardiac mechanics modeling:  http://simvascular.github.io/docsSimCardio.html#mechanics-modeling
 - Prescribed-motion LV modeling: https://simvascular.github.io/docsSimCardio.html#automatic-cardiac-modeling
-
-## License
-`svFSI` is published under the BSD 3-Clause License. Details are included in each source code file.
 
 ## Citation
 In preparation.


### PR DESCRIPTION
New CMake system has been tested with GNU / Intel compilers and with/without Trilinos.