### PR TITLE
benchmark2021 with macroscopic viscoelasticity and approx. Heaviside

### DIFF
--- a/Code/CMake/SimVascularOptions.cmake
+++ b/Code/CMake/SimVascularOptions.cmake
@@ -59,7 +59,7 @@ option(SV_USE_NOTIMER "Use notimer" ON)
 option(SV_USE_METIS_SVFSI "Use metis_svfsi Library" ON)
 option(SV_USE_PARMETIS_SVFSI "Use parmetis_svfsi Library" ON)
 option(SV_USE_TETGEN "Use tetgen Library" ON)
-option(SV_USE_TRILINOS "Use Trilinos Library with svFSI" OFF)
+option(SV_USE_TRILINOS "Use Trilinos Library with svFSI" ON)
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------

--- a/Code/Source/svFSI/ALLFUN.f
+++ b/Code/Source/svFSI/ALLFUN.f
@@ -1296,6 +1296,7 @@
       lDmn%stM%bss     = 0._RKIND
       lDmn%stM%afs     = 0._RKIND
       lDmn%stM%bfs     = 0._RKIND
+      lDmn%stM%khs     = 100._RKIND
 
       lDmn%stM%Tf%g     = 0._RKIND
       lDmn%stM%Tf%fType = 0

--- a/Code/Source/svFSI/CMakeLists.txt
+++ b/Code/Source/svFSI/CMakeLists.txt
@@ -34,7 +34,7 @@ include_directories(${SV_SOURCE_DIR}/ThirdParty/tetgen/simvascular_tetgen)
 include_directories(${MPI_C_INCLUDE_PATH})
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-  set(CMAKE_Fortran_FLAGS "-O3 -DNDEBUG -march=native")
+  set(CMAKE_Fortran_FLAGS "-O3 -DNDEBUG -march=cascadelake")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -pthread -std=legacy")
 
   # Use below flags for debugging

--- a/Code/Source/svFSI/CONSTS.f
+++ b/Code/Source/svFSI/CONSTS.f
@@ -175,14 +175,15 @@
      2   RMSH_MESHSIM = 2
 !--------------------------------------------------------------------
 !     Type of constitutive model (isochoric) for structure equation:
-!     St.Venant-Kirchhoff, modified St.Venant-Kirchhoff, NeoHookean,
-!     Mooney-Rivlin, modified Holzapfel-Gasser-Ogden with dispersion,
-!     Linear model (S = mu*I), Guccione (1995), Holzapfel & Ogden model
-!     for myocardium (2009)
-      INTEGER(KIND=IKIND), PARAMETER :: stIso_NA = 600,
-     2   stIso_StVK = 601, stIso_mStVK = 602, stIso_nHook = 603,
-     3   stIso_MR = 604, stIso_HGO = 605, stIso_lin = 606,
-     4   stIso_Gucci = 607, stIso_HO = 608
+!     Linear model (S = mu*I), St.Venant-Kirchhoff, modified St.Venant-
+!     Kirchhoff, NeoHookean, Mooney-Rivlin, Holzapfel-Gasser-Ogden with
+!     dispersion (decoupled), HGO model with modified anisotropic
+!     components, Guccione (1995), Holzapfel-Ogden (HO) model for
+!     myocardium (decoupled), HO model with modified anisotropy
+      INTEGER(KIND=IKIND), PARAMETER :: stIso_NA = 600, stIso_lin = 601,
+     2   stIso_StVK = 602, stIso_mStVK = 603, stIso_nHook = 604,
+     3   stIso_MR = 605, stIso_HGO_d = 606, stIso_HGO_ma = 607,
+     4   stIso_Gucci = 608, stIso_HO_d = 609, stIso_HO_ma = 610
 !--------------------------------------------------------------------
 !     Type of constitutive model (volumetric) for structure eqn:
 !     Quadratic, Simo-Taylor91, Miehe94

--- a/Code/Source/svFSI/DISTRIBUTE.f
+++ b/Code/Source/svFSI/DISTRIBUTE.f
@@ -1051,6 +1051,7 @@
       CALL cm%bcast(lStM%afs)
       CALL cm%bcast(lStM%bfs)
       CALL cm%bcast(lStM%kap)
+      CALL cm%bcast(lStM%khs)
 
 !     Distribute fiber stress
       CALL cm%bcast(lStM%Tf%fType)

--- a/Code/Source/svFSI/MATFUN.f
+++ b/Code/Source/svFSI/MATFUN.f
@@ -84,6 +84,40 @@
       RETURN
       END FUNCTION MAT_TRACE
 !--------------------------------------------------------------------
+!     Symmetric part of a matrix, S = (A + A.T)/2
+      FUNCTION MAT_SYMM(A, nd) RESULT(S)
+      IMPLICIT NONE
+      INTEGER(KIND=IKIND), INTENT(IN) :: nd
+      REAL(KIND=RKIND), INTENT(IN) :: A(nd,nd)
+      REAL(KIND=RKIND) :: S(nd,nd)
+
+      INTEGER(KIND=IKIND) :: i, j
+
+      S = 0._RKIND
+      DO i=1, nd
+         DO j=1, nd
+            S(i,j) = 0.5_RKIND*(A(i,j) + A(j,i))
+         END DO
+      END DO
+
+      RETURN
+      END FUNCTION MAT_SYMM
+!--------------------------------------------------------------------
+!     Deviatoric part of a matrix, D = A - (tr.(A)/nd) I
+      FUNCTION MAT_DEV(A, nd) RESULT(D)
+      IMPLICIT NONE
+      INTEGER(KIND=IKIND), INTENT(IN) :: nd
+      REAL(KIND=RKIND), INTENT(IN) :: A(nd,nd)
+      REAL(KIND=RKIND) :: D(nd,nd)
+
+      INTEGER(KIND=IKIND) :: trA
+
+      trA = MAT_TRACE(A,nd)
+      D   = A - (trA/REAL(nd,KIND=RKIND)) * MAT_ID(nd)
+
+      RETURN
+      END FUNCTION MAT_DEV
+!--------------------------------------------------------------------
 !     Create a matrix from outer product of two vectors
       FUNCTION MAT_DYADPROD(u, v, nd) RESULT(A)
       IMPLICIT NONE

--- a/Code/Source/svFSI/MATMODELS.f
+++ b/Code/Source/svFSI/MATMODELS.f
@@ -51,13 +51,13 @@
       REAL(KIND=RKIND) :: nd, Kp, J, J2d, J4d, trE, p, pl, Inv1, Inv2,
      2   Inv4, Inv6, Inv8, Tfa, IDm(nsd,nsd), C(nsd,nsd), E(nsd,nsd),
      3   Ci(nsd,nsd), Sb(nsd,nsd), CCb(nsd,nsd,nsd,nsd),
-     3   PP(nsd,nsd,nsd,nsd), CC(nsd,nsd,nsd,nsd)
-      REAL(KIND=RKIND) :: r1, r2, g1, g2, g3
+     4   PP(nsd,nsd,nsd,nsd), CC(nsd,nsd,nsd,nsd)
+      REAL(KIND=RKIND) :: r1, r2, g1, g2, g3, rexp
 !     Guccione
       REAL(KIND=RKIND) :: QQ, Rm(nsd,nsd), Es(nsd,nsd), RmRm(nsd,nsd,6)
 !     HGO/HO model
-      REAL(KIND=RKIND) :: Eff, Ess, Efs, kap, Hff(nsd,nsd),
-     4   Hss(nsd,nsd), Hfs(nsd,nsd)
+      REAL(KIND=RKIND) :: Eff, Ess, Efs, fsn, kap, c4f, c4s, dc4f, dc4s,
+     2   Hff(nsd,nsd), Hss(nsd,nsd), Hfs(nsd,nsd)
 !     Active strain for electromechanics
       REAL(KIND=RKIND) :: Fe(nsd,nsd), Fa(nsd,nsd), Fai(nsd,nsd)
 
@@ -293,6 +293,8 @@
       CASE (stIso_HO)
          IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
      2      "Holzapfel material model (2)"
+
+!        Compute fiber-based invariants
          Inv4 = J2d*NORM(fl(:,1), MATMUL(C, fl(:,1)))
          Inv6 = J2d*NORM(fl(:,2), MATMUL(C, fl(:,2)))
          Inv8 = J2d*NORM(fl(:,1), MATMUL(C, fl(:,2)))
@@ -301,43 +303,63 @@
          Ess  = Inv6 - 1._RKIND
          Efs  = Inv8
 
-         g1   = stM%a * EXP(stM%b*(Inv1-3._RKIND))
-         g2   = 2._RKIND * stM%afs * Efs * EXP(stM%bfs*Efs*Efs)
-         Hfs  = MAT_SYMMPROD(fl(:,1), fl(:,2), nsd)
-         Sb   = g1*IDm + g2*Hfs
+!        dot product: f.s
+         fsn  = NORM(fl(:,1), fl(:,2))
 
-         Efs  = Efs * Efs
-         g1   = 2._RKIND*J4d*stM%b*g1
-         g2   = 4._RKIND*J4d*stM%afs*(1._RKIND + 2._RKIND*stM%bfs*Efs)*
-     2      EXP(stM%bfs*Efs)
+!        Smoothed heaviside function
+         c4f  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Eff))
+         c4s  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Ess))
+
+!        Approx. derivative of smoothed heaviside function
+         dc4f = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Eff))
+         dc4s = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Ess))
+c         dc4f = stM%khs /
+c     2      (EXP(stM%khs*Eff) + EXP(-stM%khs*Eff) + 2.0_RKIND)
+c         dc4s = stM%khs /
+c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
+
+!        Isotropic + fiber-sheet interaction stress
+         g1   = stM%a * EXP(stM%b*(Inv1-3._RKIND))
+         g2   = 2._RKIND * stM%afs * EXP(stM%bfs*Efs*Efs) * fsn
+         Hfs  = MAT_SYMMPROD(fl(:,1), fl(:,2), nsd)
+         Sb   = g1*IDm + g2*Efs*Hfs
+
+!        Isotropic + fiber-sheet interaction stiffness
+         g1   = g1 * 2._RKIND*J4d*stM%b
+         g2   = g2 * 2._RKIND*J4d*fsn*
+     2          (1._RKIND + 2._RKIND*stM%bfs*Efs*Efs)
          CCb  = g1 * TEN_DYADPROD(IDm, IDm, nsd) +
      2          g2 * TEN_DYADPROD(Hfs, Hfs, nsd)
 
-         IF (Eff .GT. 0._RKIND) THEN
-!            Fiber reinforcement/active stress
-             g1  = Tfa
+!        Fiber-fiber interaction stress + additional reinforcement (Tfa)
+         rexp = EXP(stM%bff * Eff * Eff)
+         g1   = c4f*Eff*rexp
+         g1   = g1 + (0.5_RKIND*dc4f/stM%bff)*(rexp - 1._RKIND)
+         g1   = 2._RKIND*stM%aff*g1 + Tfa
+         Hff  = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+         Sb   = Sb + g1*Hff
 
-             g1  = g1 + 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff)
-             Hff = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
-             Sb  = Sb + g1*Hff
+!        Fiber-fiber interaction stiffness
+         g1   = c4f*(1._RKIND + 2._RKIND*stM%bff*Eff*Eff)
+         g1   = (g1 + 2._RKIND*dc4f*Eff)*rexp
+         g1   = 4._RKIND*J4d*stM%aff*g1
+         CCb  = CCb + g1*TEN_DYADPROD(Hff, Hff, nsd)
 
-             Eff = Eff * Eff
-             g1  = 4._RKIND*J4d*stM%aff*(1._RKIND +
-     2          2._RKIND*stM%bff*Eff)*EXP(stM%bff*Eff)
-             CCb = CCb + g1*TEN_DYADPROD(Hff, Hff, nsd)
-         END IF
+!        Sheet-sheet interaction stress
+         rexp = EXP(stM%bss * Ess * Ess)
+         g2   = c4s*Ess*rexp
+         g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
+         g2   = 2._RKIND*stM%ass*g2
+         Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
+         Sb   = Sb + g2*Hss
 
-         IF (Ess .GT. 0._RKIND) THEN
-             g2  = 2._RKIND * stM%ass * Ess * EXP(stM%bss*Ess*Ess)
-             Hss = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
-             Sb  = Sb + g2*Hss
+!        Sheet-sheet interaction stiffness
+         g2   = c4s*(1._RKIND + 2._RKIND*stM%bss*Ess*Ess)
+         g2   = (g2 + 2._RKIND*dc4s*Ess)*rexp
+         g2   = 4._RKIND*J4d*stM%ass*g2
+         CCb  = CCb + g2*TEN_DYADPROD(Hss, Hss, nsd)
 
-             Ess = Ess * Ess
-             g2  = 4._RKIND*J4d*stM%ass*(1._RKIND +
-     2          2._RKIND*stM%bss*Ess)*EXP(stM%bss*Ess)
-             CCb = CCb + g2*TEN_DYADPROD(Hss, Hss, nsd)
-         END IF
-
+!        Isochoric 2nd-Piola-Kirchhoff stress and stiffness tensors
          r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
          S   = J2d*Sb - r1*Ci
 
@@ -348,10 +370,12 @@
          CC  = CC - (2._RKIND/nd) * ( TEN_DYADPROD(Ci, S, nsd) +
      2                           TEN_DYADPROD(S, Ci, nsd) )
 
+!        Add pressure contribution
          S   = S + p*J*Ci
          CC  = CC + 2._RKIND*(r1 - p*J) * TEN_SYMMPROD(Ci, Ci, nsd) +
      2          (pl*J - 2._RKIND*r1/nd) * TEN_DYADPROD(Ci, Ci, nsd)
 
+!        Contribution from active strain
          IF (cem%aStrain) THEN
             S = MATMUL(Fai, S)
             S = MATMUL(S, TRANSPOSE(Fai))
@@ -414,12 +438,12 @@
      2   Inv8, Tfa, IDm(nsd,nsd), C(nsd,nsd), E(nsd,nsd), Ci(nsd,nsd),
      3   Sb(nsd,nsd), CCb(nsd,nsd,nsd,nsd), PP(nsd,nsd,nsd,nsd),
      4   CC(nsd,nsd,nsd,nsd)
-      REAL(KIND=RKIND) :: r1, r2, g1, g2, g3
+      REAL(KIND=RKIND) :: r1, r2, g1, g2, g3, rexp
       ! Guccione !
       REAL(KIND=RKIND) :: QQ, Rm(nsd,nsd), Es(nsd,nsd), RmRm(nsd,nsd,6)
       ! HGO, HO !
-      REAL(KIND=RKIND) :: kap, Eff, Ess, Efs, Hff(nsd,nsd),
-     2   Hss(nsd,nsd), Hfs(nsd,nsd)
+      REAL(KIND=RKIND) :: Eff, Ess, Efs, fsn, kap, c4f, c4s, dc4f, dc4s,
+     2   Hff(nsd,nsd), Hss(nsd,nsd), Hfs(nsd,nsd)
 !     Active strain for electromechanics
       REAL(KIND=RKIND) :: Fe(nsd,nsd), Fa(nsd,nsd), Fai(nsd,nsd)
 
@@ -619,6 +643,8 @@
       CASE (stIso_HO)
          IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
      2      "Holzapfel material model (2)"
+
+!        Compute fiber-based invariants
          Inv4 = J2d*NORM(fl(:,1), MATMUL(C, fl(:,1)))
          Inv6 = J2d*NORM(fl(:,2), MATMUL(C, fl(:,2)))
          Inv8 = J2d*NORM(fl(:,1), MATMUL(C, fl(:,2)))
@@ -627,43 +653,63 @@
          Ess  = Inv6 - 1._RKIND
          Efs  = Inv8
 
-         g1   = stM%a * EXP(stM%b*(Inv1-3._RKIND))
-         g2   = 2._RKIND * stM%afs * Efs * EXP(stM%bfs*Efs*Efs)
-         Hfs  = MAT_SYMMPROD(fl(:,1), fl(:,2), nsd)
-         Sb   = g1*IDm + g2*Hfs
+!        dot product: f.s
+         fsn  = NORM(fl(:,1), fl(:,2))
 
-         Efs  = Efs * Efs
-         g1   = 2._RKIND*J4d*stM%b*g1
-         g2   = 4._RKIND*J4d*stM%afs*(1._RKIND + 2._RKIND*stM%bfs*Efs)*
-     2      EXP(stM%bfs*Efs)
+!        Smoothed heaviside function
+         c4f  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Eff))
+         c4s  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Ess))
+
+!        Approx. derivative of smoothed heaviside function
+         dc4f = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Eff))
+         dc4s = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Ess))
+c         dc4f = stM%khs /
+c     2      (EXP(stM%khs*Eff) + EXP(-stM%khs*Eff) + 2.0_RKIND)
+c         dc4s = stM%khs /
+c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
+
+!        Isotropic + fiber-sheet interaction stress
+         g1   = stM%a * EXP(stM%b*(Inv1-3._RKIND))
+         g2   = 2._RKIND * stM%afs * EXP(stM%bfs*Efs*Efs) * fsn
+         Hfs  = MAT_SYMMPROD(fl(:,1), fl(:,2), nsd)
+         Sb   = g1*IDm + g2*Efs*Hfs
+
+!        Isotropic + fiber-sheet interaction stiffness
+         g1   = g1 * 2._RKIND*J4d*stM%b
+         g2   = g2 * 2._RKIND*J4d*fsn*
+     2          (1._RKIND + 2._RKIND*stM%bfs*Efs*Efs)
          CCb  = g1 * TEN_DYADPROD(IDm, IDm, nsd) +
      2          g2 * TEN_DYADPROD(Hfs, Hfs, nsd)
 
-         IF (Eff .GT. 0._RKIND) THEN
-!            Fiber reinforcement/active stress
-             g1  = Tfa
+!        Fiber-fiber interaction stress + additional reinforcement (Tfa)
+         rexp = EXP(stM%bff * Eff * Eff)
+         g1   = c4f*Eff*rexp
+         g1   = g1 + (0.5_RKIND*dc4f/stM%bff)*(rexp - 1._RKIND)
+         g1   = 2._RKIND*stM%aff*g1 + Tfa
+         Hff  = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+         Sb   = Sb + g1*Hff
 
-             g1  = g1 + 2._RKIND * stM%aff * Eff * EXP(stM%bff*Eff*Eff)
-             Hff = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
-             Sb  = Sb + g1*Hff
+!        Fiber-fiber interaction stiffness
+         g1   = c4f*(1._RKIND + 2._RKIND*stM%bff*Eff*Eff)
+         g1   = (g1 + 2._RKIND*dc4f*Eff)*rexp
+         g1   = 4._RKIND*J4d*stM%aff*g1
+         CCb  = CCb + g1*TEN_DYADPROD(Hff, Hff, nsd)
 
-             Eff = Eff * Eff
-             g1  = 4._RKIND*J4d*stM%aff*(1._RKIND +
-     2          2._RKIND*stM%bff*Eff)*EXP(stM%bff*Eff)
-             CCb = CCb + g1*TEN_DYADPROD(Hff, Hff, nsd)
-         END IF
+!        Sheet-sheet interaction stress
+         rexp = EXP(stM%bss * Ess * Ess)
+         g2   = c4s*Ess*rexp
+         g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
+         g2   = 2._RKIND*stM%ass*g2
+         Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
+         Sb   = Sb + g2*Hss
 
-         IF (Ess .GT. 0._RKIND) THEN
-             g2  = 2._RKIND * stM%ass * Ess * EXP(stM%bss*Ess*Ess)
-             Hss = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
-             Sb  = Sb + g2*Hss
+!        Sheet-sheet interaction stiffness
+         g2   = c4s*(1._RKIND + 2._RKIND*stM%bss*Ess*Ess)
+         g2   = (g2 + 2._RKIND*dc4s*Ess)*rexp
+         g2   = 4._RKIND*J4d*stM%ass*g2
+         CCb  = CCb + g2*TEN_DYADPROD(Hss, Hss, nsd)
 
-             Ess = Ess * Ess
-             g2  = 4._RKIND*J4d*stM%ass*(1._RKIND +
-     2          2._RKIND*stM%bss*Ess)*EXP(stM%bss*Ess)
-             CCb = CCb + g2*TEN_DYADPROD(Hss, Hss, nsd)
-         END IF
-
+!        Isochoric 2nd-Piola-Kirchhoff stress and stiffness tensors
          r1  = J2d*MAT_DDOT(C, Sb, nsd) / nd
          S   = J2d*Sb - r1*Ci
 
@@ -676,6 +722,7 @@
      3            - 2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
      4                         TEN_DYADPROD(S, Ci, nsd) )
 
+!        Contribution from active strain
          IF (cem%aStrain) THEN
             S = MATMUL(Fai, S)
             S = MATMUL(S, TRANSPOSE(Fai))

--- a/Code/Source/svFSI/MATMODELS.f
+++ b/Code/Source/svFSI/MATMODELS.f
@@ -170,9 +170,9 @@
          CC  = CC + 2._RKIND*(r1 - p*J) * TEN_SYMMPROD(Ci, Ci, nsd) +
      2          (pl*J - 2._RKIND*r1/nd) * TEN_DYADPROD(Ci, Ci, nsd)
 
-!     HGO (Holzapfel-Gasser-Ogden) model with additive splitting of
-!     the anisotropic fiber-based strain-energy terms
-      CASE (stIso_HGO)
+!     HGO (Holzapfel-Gasser-Ogden) model for arteries with isochoric
+!     invariants for the anisotropy terms (decoupled)
+      CASE (stIso_HGO_d)
          IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
      2      "HGO material model (2)"
          kap  = stM%kap
@@ -218,6 +218,55 @@
          S   = S + p*J*Ci
          CC  = CC + 2._RKIND*(r1 - p*J) * TEN_SYMMPROD(Ci, Ci, nsd) +
      2          (pl*J - 2._RKIND*r1/nd) * TEN_DYADPROD(Ci, Ci, nsd)
+
+!     HGO (Holzapfel-Gasser-Ogden) model for arteries with full
+!     invariants for the anisotropy terms (modified-anisotropy)
+      CASE (stIso_HGO_ma)
+         IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
+     2      "HGO material model (2)"
+         kap  = stM%kap
+         Inv1 = MAT_TRACE(C,nsd)
+         Inv4 = NORM(fl(:,1), MATMUL(C, fl(:,1)))
+         Inv6 = NORM(fl(:,2), MATMUL(C, fl(:,2)))
+
+         Eff  = kap*Inv1 + (1._RKIND-3._RKIND*kap)*Inv4 - 1._RKIND
+         Ess  = kap*Inv1 + (1._RKIND-3._RKIND*kap)*Inv6 - 1._RKIND
+
+!        Isochoric and volumetric contribution to stress and stiffness
+!        tensors
+         Sb   = 2._RKIND*stM%C10*IDm
+         r1   = J2d*MAT_DDOT(C, Sb, nsd) / nd
+
+         S    = J2d*Sb - r1*Ci
+         CC   = -2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
+     2                           TEN_DYADPROD(S, Ci, nsd) )
+
+         S    = S + p*J*Ci
+         CC   = CC + 2._RKIND*(r1 - p*J) * TEN_SYMMPROD(Ci, Ci, nsd)
+     2        +  (pl*J - 2._RKIND*r1/nd) * TEN_DYADPROD(Ci, Ci, nsd)
+
+!        Anisotropic contribution to stress and stiffness tensors
+!        Fiber-Fiber interaction + additional fiber reinforcement
+         rexp = EXP(stM%bff*Eff*Eff)
+         g1   = 2._RKIND*stM%aff*Eff*rexp
+         Hff  = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+         Hff  = kap*IDm + (1._RKIND-3._RKIND*kap)*Hff
+         S    = S + (g1*Hff) + (Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd))
+
+         g1   = (1._RKIND + (2._RKIND*stM%bff*Eff*Eff))
+         g1   = 4._RKIND*stM%aff*g1*rexp
+         CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
+
+!        Sheet-Sheet interaction
+         rexp = EXP(stM%bss*Ess*Ess)
+         g2   = 2._RKIND*stM%ass*Ess*rexp
+         Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
+         Hss  = kap*IDm + (1._RKIND-3._RKIND*kap)*Hss
+         S    = S + (g2*Hss)
+
+         g2   = (1._RKIND + (2._RKIND*stM%bss*Ess*Ess))
+         g2   = 4._RKIND*stM%ass*g2*rexp
+         CC   = CC + (g2*TEN_DYADPROD(Hss, Hss, nsd))
 
 !     Guccione (1995) transversely isotropic model
       CASE (stIso_Gucci)
@@ -289,8 +338,9 @@
          CC  = CC + 2._RKIND*(r1 - p*J) * TEN_SYMMPROD(Ci, Ci, nsd) +
      2          (pl*J - 2._RKIND*r1/nd) * TEN_DYADPROD(Ci, Ci, nsd)
 
-!     HO (Holzapfel-Ogden) model for myocardium (2009)
-      CASE (stIso_HO)
+!     HO (Holzapfel-Ogden) model for myocardium with isoschoric
+!     invariants for the anisotropy terms (decoupled)
+      CASE (stIso_HO_d)
          IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
      2      "Holzapfel material model (2)"
 
@@ -374,6 +424,108 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
          S   = S + p*J*Ci
          CC  = CC + 2._RKIND*(r1 - p*J) * TEN_SYMMPROD(Ci, Ci, nsd) +
      2          (pl*J - 2._RKIND*r1/nd) * TEN_DYADPROD(Ci, Ci, nsd)
+
+!        Contribution from active strain
+         IF (cem%aStrain) THEN
+            S = MATMUL(Fai, S)
+            S = MATMUL(S, TRANSPOSE(Fai))
+            CCb = 0._RKIND
+            CCb = TEN_DYADPROD(Fai, Fai, nsd)
+            CC  = TEN_DDOT_3424(CC, CCb, nsd)
+            CC  = TEN_DDOT_2412(CCb, CC, nsd)
+         END IF
+
+!     HO (Holzapfel-Ogden) model for myocardium with full invariants
+!     for the anisotropy terms (modified-anisotropy)
+      CASE (stIso_HO_ma)
+         IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
+     2      "Holzapfel material model (2)"
+
+!        Compute fiber-based full invariants (not isochoric)
+         Inv4 = NORM(fl(:,1), MATMUL(C, fl(:,1)))
+         Inv6 = NORM(fl(:,2), MATMUL(C, fl(:,2)))
+         Inv8 = NORM(fl(:,1), MATMUL(C, fl(:,2)))
+
+         Eff  = Inv4 - 1._RKIND
+         Ess  = Inv6 - 1._RKIND
+         Efs  = Inv8
+
+!        dot product: f.s
+         fsn  = NORM(fl(:,1), fl(:,2))
+
+!        Smoothed heaviside function
+         c4f  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Eff))
+         c4s  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Ess))
+
+!        Approx. derivative of smoothed heaviside function
+         dc4f = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Eff))
+         dc4s = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Ess))
+c         dc4f = stM%khs /
+c     2      (EXP(stM%khs*Eff) + EXP(-stM%khs*Eff) + 2.0_RKIND)
+c         dc4s = stM%khs /
+c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
+
+!        Isochoric stress and stiffness
+         g1   = stM%a * EXP(stM%b*(Inv1-3._RKIND))
+         Sb   = g1*IDm
+         r1   = J2d*MAT_DDOT(C, Sb, nsd) / nd
+
+         g1   = g1 * 2._RKIND*J4d*stM%b
+         CCb  = g1 * TEN_DYADPROD(IDm, IDm, nsd)
+
+!        Add isochoric stress and stiffness contribution
+         S    = J2d*Sb - r1*Ci
+
+         PP   = TEN_IDs(nsd) - (1._RKIND/nd) * TEN_DYADPROD(Ci, C, nsd)
+         CC   = TEN_DDOT(CCb, PP, nsd)
+         CC   = TEN_TRANSPOSE(CC, nsd)
+         CC   = TEN_DDOT(PP, CC, nsd)
+         CC   = CC - (2._RKIND/nd) * ( TEN_DYADPROD(Ci, S, nsd) +
+     2                                 TEN_DYADPROD(S, Ci, nsd) )
+
+!        Add pressure contribution to stress and stiffness
+         S    = S + p*J*Ci
+         CC   = CC + 2._RKIND*(r1 - p*J) * TEN_SYMMPROD(Ci, Ci, nsd)
+     2         + (pl*J - 2._RKIND*r1/nd) * TEN_DYADPROD(Ci, Ci, nsd)
+
+!        Now that both isochoric and volumetric components were added,
+!        anisotropic components need to be added
+
+!        Fiber-sheet interaction terms
+         g1   = 2._RKIND * stM%afs * EXP(stM%bfs*Efs*Efs) * fsn
+         Hfs  = MAT_SYMMPROD(fl(:,1), fl(:,2), nsd)
+         S    = S + (g1*Efs*Hfs)
+
+         g1   = g1 * 2._RKIND*fsn*(1._RKIND + 2._RKIND*stM%bfs*Efs*Efs)
+         CC   = CC + (g1*TEN_DYADPROD(Hfs, Hfs, nsd))
+
+!        Fiber-fiber interaction stress + additional reinforcement (Tfa)
+         rexp = EXP(stM%bff * Eff * Eff)
+         g1   = c4f*Eff*rexp
+         g1   = g1 + (0.5_RKIND*dc4f/stM%bff)*(rexp - 1._RKIND)
+         g1   = (2._RKIND*stM%aff*g1) + Tfa
+         Hff  = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+         S    = S + (g1*Hff)
+
+!        Fiber-fiber interaction stiffness
+         g1   = c4f*(1._RKIND + (2._RKIND*stM%bff*Eff*Eff))
+         g1   = (g1 + (2._RKIND*dc4f*Eff))*rexp
+         g1   = 4._RKIND*stM%aff*g1
+         CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
+
+!        Sheet-sheet interaction stress
+         rexp = EXP(stM%bss * Ess * Ess)
+         g2   = c4s*Ess*rexp
+         g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
+         g2   = 2._RKIND*stM%ass*g2
+         Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
+         S    = S + (g2*Hss)
+
+!        Sheet-sheet interaction stiffness
+         g2   = c4s*(1._RKIND + (2._RKIND*stM%bss*Ess*Ess))
+         g2   = (g2 + (2._RKIND*dc4s*Ess))*rexp
+         g2   = 4._RKIND*stM%ass*g2
+         CC   = CC + (g2*TEN_DYADPROD(Hss, Hss, nsd))
 
 !        Contribution from active strain
          IF (cem%aStrain) THEN
@@ -525,9 +677,9 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
      3            - 2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
      4                         TEN_DYADPROD(S, Ci, nsd) )
 
-!     HGO (Holzapfel-Gasser-Ogden) model with additive splitting of
-!     the anisotropic fiber-based strain-energy terms
-      CASE (stIso_HGO)
+!     HGO (Holzapfel-Gasser-Ogden) model for arteries with isochoric
+!     invariants for the anisotropy terms (decoupled)
+      CASE (stIso_HGO_d)
          IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
      2      "HGO material model (2)"
          kap  = stM%kap
@@ -571,6 +723,52 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
      2              1._RKIND/nd *   TEN_DYADPROD(Ci, Ci, nsd) )
      3            - 2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
      4                         TEN_DYADPROD(S, Ci, nsd) )
+
+!     HGO (Holzapfel-Gasser-Ogden) model for arteries with full
+!     invariants for the anisotropy terms (modified-anisotropy)
+      CASE (stIso_HGO_ma)
+         IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
+     2      "HGO material model (2)"
+         kap  = stM%kap
+         Inv1 = MAT_TRACE(C,nsd)
+         Inv4 = NORM(fl(:,1), MATMUL(C, fl(:,1)))
+         Inv6 = NORM(fl(:,2), MATMUL(C, fl(:,2)))
+
+         Eff  = kap*Inv1 + (1._RKIND-3._RKIND*kap)*Inv4 - 1._RKIND
+         Ess  = kap*Inv1 + (1._RKIND-3._RKIND*kap)*Inv6 - 1._RKIND
+
+!        Isochoric contribution to stress and stiffness tensors
+         Sb   = 2._RKIND*stM%C10*IDm
+         r1   = J2d*MAT_DDOT(C, Sb, nsd) / nd
+
+         S    = J2d*Sb - r1*Ci
+         CC   = 2._RKIND*r1 * ( TEN_SYMMPROD(Ci, Ci, nsd) -
+     2          1._RKIND/nd *   TEN_DYADPROD(Ci, Ci, nsd) )
+     3        - 2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
+     4                          TEN_DYADPROD(S, Ci, nsd) )
+
+!        Anisotropic contribution to stress and stiffness tensors
+!        Fiber-Fiber interaction + additional fiber reinforcement
+         rexp = EXP(stM%bff*Eff*Eff)
+         g1   = 2._RKIND*stM%aff*Eff*rexp
+         Hff  = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+         Hff  = kap*IDm + (1._RKIND-3._RKIND*kap)*Hff
+         S    = S + (g1*Hff) + (Tfa*MAT_DYADPROD(fl(:,1), fl(:,1), nsd))
+
+         g1   = (1._RKIND + (2._RKIND*stM%bff*Eff*Eff))
+         g1   = 4._RKIND*stM%aff*g1*rexp
+         CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
+
+!        Sheet-Sheet interaction
+         rexp = EXP(stM%bss*Ess*Ess)
+         g2   = 2._RKIND*stM%ass*Ess*rexp
+         Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
+         Hss  = kap*IDm + (1._RKIND-3._RKIND*kap)*Hss
+         S    = S + (g2*Hss)
+
+         g2   = (1._RKIND + (2._RKIND*stM%bss*Ess*Ess))
+         g2   = 4._RKIND*stM%ass*g2*rexp
+         CC   = CC + (g2*TEN_DYADPROD(Hss, Hss, nsd))
 
 !     Guccione (1995) transversely isotropic model
       CASE (stIso_Gucci)
@@ -639,8 +837,9 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
      3            - 2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
      4                         TEN_DYADPROD(S, Ci, nsd) )
 
-!     HO (Holzapfel-Ogden) model for myocardium (2009)
-      CASE (stIso_HO)
+!     HO (Holzapfel-Ogden) model for myocardium with isoschoric
+!     invariants for the anisotropy terms (decoupled)
+      CASE (stIso_HO_d)
          IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
      2      "Holzapfel material model (2)"
 
@@ -721,6 +920,103 @@ c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
      2              1._RKIND/nd *   TEN_DYADPROD(Ci, Ci, nsd) )
      3            - 2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
      4                         TEN_DYADPROD(S, Ci, nsd) )
+
+!        Contribution from active strain
+         IF (cem%aStrain) THEN
+            S = MATMUL(Fai, S)
+            S = MATMUL(S, TRANSPOSE(Fai))
+            CCb = 0._RKIND
+            CCb = TEN_DYADPROD(Fai, Fai, nsd)
+            CC  = TEN_DDOT_3424(CC, CCb, nsd)
+            CC  = TEN_DDOT_2412(CCb, CC, nsd)
+         END IF
+
+!     HO (Holzapfel-Ogden) model for myocardium with full invariants
+!     for the anisotropy terms (modified-anisotropy)
+      CASE (stIso_HO_ma)
+         IF (nfd .NE. 2) err = "Min fiber directions not defined for "//
+     2      "Holzapfel material model (2)"
+
+!        Compute fiber-based invariants
+         Inv4 = NORM(fl(:,1), MATMUL(C, fl(:,1)))
+         Inv6 = NORM(fl(:,2), MATMUL(C, fl(:,2)))
+         Inv8 = NORM(fl(:,1), MATMUL(C, fl(:,2)))
+
+         Eff  = Inv4 - 1._RKIND
+         Ess  = Inv6 - 1._RKIND
+         Efs  = Inv8
+
+!        dot product: f.s
+         fsn  = NORM(fl(:,1), fl(:,2))
+
+!        Smoothed heaviside function
+         c4f  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Eff))
+         c4s  = 1._RKIND / (1._RKIND + EXP(-stM%khs*Ess))
+
+!        Approx. derivative of smoothed heaviside function
+         dc4f = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Eff))
+         dc4s = 0.25_RKIND*stM%khs*EXP(-stM%khs*ABS(Ess))
+c         dc4f = stM%khs /
+c     2      (EXP(stM%khs*Eff) + EXP(-stM%khs*Eff) + 2.0_RKIND)
+c         dc4s = stM%khs /
+c     2      (EXP(stM%khs*Ess) + EXP(-stM%khs*Ess) + 2.0_RKIND)
+
+!        Isochoric stress and stiffness
+         g1   = stM%a * EXP(stM%b*(Inv1-3._RKIND))
+         Sb   = g1*IDm
+         r1   = J2d*MAT_DDOT(C, Sb, nsd) / nd
+
+         g1   = g1 * 2._RKIND*J4d*stM%b
+         CCb  = g1 * TEN_DYADPROD(IDm, IDm, nsd)
+
+!        Add isochoric stress and stiffness contribution
+         S    = J2d*Sb - r1*Ci
+
+         PP   = TEN_IDs(nsd) - (1._RKIND/nd) * TEN_DYADPROD(Ci, C, nsd)
+         CC   = TEN_DDOT(CCb, PP, nsd)
+         CC   = TEN_TRANSPOSE(CC, nsd)
+         CC   = TEN_DDOT(PP, CC, nsd)
+         CC   = CC + 2._RKIND*r1 * ( TEN_SYMMPROD(Ci, Ci, nsd) -
+     2               1._RKIND/nd *   TEN_DYADPROD(Ci, Ci, nsd) )
+     3             - 2._RKIND/nd * ( TEN_DYADPROD(Ci, S, nsd) +
+     4                               TEN_DYADPROD(S, Ci, nsd) )
+
+!        Now add anisotropic components
+!        Fiber-sheet interaction terms
+         g1   = 2._RKIND * stM%afs * EXP(stM%bfs*Efs*Efs) * fsn
+         Hfs  = MAT_SYMMPROD(fl(:,1), fl(:,2), nsd)
+         S    = S + (g1*Efs*Hfs)
+
+         g1   = g1 * 2._RKIND*fsn*(1._RKIND + 2._RKIND*stM%bfs*Efs*Efs)
+         CC   = CC + (g1*TEN_DYADPROD(Hfs, Hfs, nsd))
+
+!        Fiber-fiber interaction stress + additional reinforcement (Tfa)
+         rexp = EXP(stM%bff * Eff * Eff)
+         g1   = c4f*Eff*rexp
+         g1   = g1 + (0.5_RKIND*dc4f/stM%bff)*(rexp - 1._RKIND)
+         g1   = (2._RKIND*stM%aff*g1) + Tfa
+         Hff  = MAT_DYADPROD(fl(:,1), fl(:,1), nsd)
+         S    = S + (g1*Hff)
+
+!        Fiber-fiber interaction stiffness
+         g1   = c4f*(1._RKIND + (2._RKIND*stM%bff*Eff*Eff))
+         g1   = (g1 + (2._RKIND*dc4f*Eff))*rexp
+         g1   = 4._RKIND*stM%aff*g1
+         CC   = CC + (g1*TEN_DYADPROD(Hff, Hff, nsd))
+
+!        Sheet-sheet interaction stress
+         rexp = EXP(stM%bss * Ess * Ess)
+         g2   = c4s*Ess*rexp
+         g2   = g2 + (0.5_RKIND*dc4s/stM%bss)*(rexp - 1._RKIND)
+         g2   = 2._RKIND*stM%ass*g2
+         Hss  = MAT_DYADPROD(fl(:,2), fl(:,2), nsd)
+         S    = S + (g2*Hss)
+
+!        Sheet-sheet interaction stiffness
+         g2   = c4s*(1._RKIND + (2._RKIND*stM%bss*Ess*Ess))
+         g2   = (g2 + (2._RKIND*dc4s*Ess))*rexp
+         g2   = 4._RKIND*stM%ass*g2
+         CC   = CC + (g2*TEN_DYADPROD(Hss, Hss, nsd))
 
 !        Contribution from active strain
          IF (cem%aStrain) THEN

--- a/Code/Source/svFSI/MOD.f
+++ b/Code/Source/svFSI/MOD.f
@@ -227,7 +227,8 @@
          REAL(KIND=RKIND) :: C10 = 0._RKIND
 !        Mooney-Rivlin model (C10, C01)
          REAL(KIND=RKIND) :: C01 = 0._RKIND
-!        Holzapfel model(a, b, aff, bff, ass, bss, afs, bfs, kap)
+!        Holzapfel-Ogden / HGO model
+!        (a, b, aff, bff, ass, bss, afs, bfs, kap, khs)
          REAL(KIND=RKIND) :: a   = 0._RKIND
          REAL(KIND=RKIND) :: b   = 0._RKIND
          REAL(KIND=RKIND) :: aff = 0._RKIND
@@ -236,8 +237,10 @@
          REAL(KIND=RKIND) :: bss = 0._RKIND
          REAL(KIND=RKIND) :: afs = 0._RKIND
          REAL(KIND=RKIND) :: bfs = 0._RKIND
-!        Collagen fiber dispersion parameter (Holzapfel model)
+!        Collagen fiber dispersion parameter (HGO model)
          REAL(KIND=RKIND) :: kap = 0._RKIND
+!        Heaviside function parameter (Holzapfel-Ogden model)
+         REAL(KIND=RKIND) :: khs = 100._RKIND
 !        Fiber reinforcement stress
          TYPE(fibStrsType) :: Tf
       END TYPE stModelType

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -297,7 +297,7 @@
                DO i=1, eq(iEq)%nDmn
                   IF (eq(iEq)%dmn(i)%phys .NE. phys_ustruct .AND.
      2                eq(iEq)%dmn(i)%phys .NE. phys_struct) CYCLE
-                  IF (eq(iEq)%dmn(i)%stM%isoType .NE. stIso_HO) err =
+                  IF (eq(iEq)%dmn(i)%stM%isoType .NE. stIso_HO_d) err =
      2               "Active strain is allowed with Holzapfel-Ogden "//
      3               "passive constitutive model only"
                END DO
@@ -2454,9 +2454,19 @@ c     2         "can be applied for Neumann boundaries only"
          lPtr => lSt%get(lDmn%stM%C10, "c1")
          lPtr => lSt%get(lDmn%stM%C01, "c2")
 
-      CASE ("HGO")
+      CASE ("HGO", "HGO-decoupled", "HGO-d")
       ! Neo-Hookean ground matrix + quad penalty + anistropic fibers !
-         lDmn%stM%isoType = stIso_HGO
+         lDmn%stM%isoType = stIso_HGO_d
+         lDmn%stM%C10 = mu*0.5_RKIND
+         lPtr => lSt%get(lDmn%stM%aff, "a4")
+         lPtr => lSt%get(lDmn%stM%bff, "b4")
+         lPtr => lSt%get(lDmn%stM%ass, "a6")
+         lPtr => lSt%get(lDmn%stM%bss, "b6")
+         lPtr => lSt%get(lDmn%stM%kap, "kappa")
+
+      CASE ("HGO-ma", "HGO-modified")
+      ! Neo-Hookean ground matrix + quad penalty + anistropic fibers !
+         lDmn%stM%isoType = stIso_HGO_ma
          lDmn%stM%C10 = mu*0.5_RKIND
          lPtr => lSt%get(lDmn%stM%aff, "a4")
          lPtr => lSt%get(lDmn%stM%bff, "b4")
@@ -2475,9 +2485,22 @@ c     2         "can be applied for Neumann boundaries only"
      2         "with 2 family of directions"
          END IF
 
-      CASE ("HO", "Holzapfel")
+      CASE ("HO", "Holzapfel", "HO-decoupled", "HO-d")
       ! Holzapefel and Ogden model for myocardium !
-         lDmn%stM%isoType = stIso_HO
+         lDmn%stM%isoType = stIso_HO_d
+         lPtr => lSt%get(lDmn%stM%a, "a")
+         lPtr => lSt%get(lDmn%stM%b, "b")
+         lPtr => lSt%get(lDmn%stM%aff, "a4f")
+         lPtr => lSt%get(lDmn%stM%bff, "b4f")
+         lPtr => lSt%get(lDmn%stM%ass, "a4s")
+         lPtr => lSt%get(lDmn%stM%bss, "b4s")
+         lPtr => lSt%get(lDmn%stM%afs, "afs")
+         lPtr => lSt%get(lDmn%stM%bfs, "bfs")
+         lPtr => lSt%get(lDmn%stM%khs, "k")
+
+      CASE ("HO-ma", "HO-modified")
+      ! Holzapefel and Ogden model for myocardium !
+         lDmn%stM%isoType = stIso_HO_ma
          lPtr => lSt%get(lDmn%stM%a, "a")
          lPtr => lSt%get(lDmn%stM%b, "b")
          lPtr => lSt%get(lDmn%stM%aff, "a4f")

--- a/Code/Source/svFSI/READFILES.f
+++ b/Code/Source/svFSI/READFILES.f
@@ -513,9 +513,10 @@
          propL(2,1) = damping
          propL(3,1) = elasticity_modulus
          propL(4,1) = poisson_ratio
-         propL(5,1) = f_x
-         propL(6,1) = f_y
-         IF (nsd .EQ. 3) propL(7,1) = f_z
+         propL(5,1) = solid_viscosity
+         propL(6,1) = f_x
+         propL(7,1) = f_y
+         IF (nsd .EQ. 3) propL(8,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
          lPtr => list%get(pstEq, "Prestress")
@@ -553,11 +554,12 @@
          propL(1,1) = solid_density
          propL(2,1) = elasticity_modulus
          propL(3,1) = poisson_ratio
-         propL(4,1) = ctau_M
-         propL(5,1) = ctau_C
-         propL(6,1) = f_x
-         propL(7,1) = f_y
-         IF (nsd .EQ. 3) propL(8,1) = f_z
+         propL(4,1) = solid_viscosity
+         propL(5,1) = ctau_M
+         propL(6,1) = ctau_C
+         propL(7,1) = f_x
+         propL(8,1) = f_y
+         IF (nsd .EQ. 3) propL(9,1) = f_z
          CALL READDOMAIN(lEq, propL, list)
 
          lPtr => list%get(pstEq, "Prestress")
@@ -1038,6 +1040,8 @@
             CASE (poisson_ratio)
                lPtr => lPD%get(rtmp,"Poisson ratio",1,ll=0._RKIND,
      2            ul=0.5_RKIND)
+            CASE (solid_viscosity)
+               lPtr => lPD%get(rtmp,"Viscosity",ll=0._RKIND)
             CASE (conductivity)
                lPtr => lPD%get(rtmp,"Conductivity",1,ll=0._RKIND)
             CASE (f_x)
@@ -2482,6 +2486,7 @@ c     2         "can be applied for Neumann boundaries only"
          lPtr => lSt%get(lDmn%stM%bss, "b4s")
          lPtr => lSt%get(lDmn%stM%afs, "afs")
          lPtr => lSt%get(lDmn%stM%bfs, "bfs")
+         lPtr => lSt%get(lDmn%stM%khs, "k")
 
       CASE DEFAULT
          err = "Undefined constitutive model used"

--- a/Code/Source/svFSI/SETBC.f
+++ b/Code/Source/svFSI/SETBC.f
@@ -426,7 +426,7 @@
      2   Dg(tDof,tnNo)
 
       INTEGER(KIND=IKIND) :: a, b, e, g, s, Ac, iM, eNoN, cPhys
-      REAL(KIND=RKIND) :: Jac, af, am, afm, w, wl, T1, T2, nV(nsd),
+      REAL(KIND=RKIND) :: Jac, afu, afv, afm, w, wl, T1, T2, nV(nsd),
      2   u(nsd), ud(nsd), h(nsd), nDn(nsd,nsd)
 
       INTEGER(KIND=IKIND), ALLOCATABLE :: ptr(:)
@@ -434,9 +434,9 @@
      2   lR(:,:), lK(:,:,:), lKd(:,:,:)
 
       s   = eq(cEq)%s
-      am  = eq(cEq)%af*eq(cEq)%gam*dt
-      af  = eq(cEq)%af*eq(cEq)%beta*dt*dt
-      afm = am/eq(cEq)%am
+      afv = eq(cEq)%af*eq(cEq)%gam*dt
+      afu = eq(cEq)%af*eq(cEq)%beta*dt*dt
+      afm = afv/eq(cEq)%am
 
       iM   = lFa%iM
       eNoN = lFa%eNoN
@@ -494,7 +494,7 @@
                END DO
 
                IF (cPhys .EQ. phys_ustruct) THEN
-                  wl = w*af
+                  wl = w*afv
                   DO a=1, eNoN
                      DO b=1, eNoN
                         T1 = wl*N(a)*N(b)
@@ -539,7 +539,7 @@
                      END DO
                   END DO
                ELSE
-                  wl = w*(ks*af + cs*am)
+                  wl = w*(ks*afu + cs*afv)
                   DO a=1, eNoN
                      DO b=1, eNoN
                         T1 = N(a)*N(b)
@@ -564,7 +564,7 @@
                END DO
 
                IF (cPhys .EQ. phys_ustruct) THEN
-                  wl = w*af
+                  wl = w*afv
                   DO a=1, eNoN
                      DO b=1, eNoN
                         T1 = wl*N(a)*N(b)
@@ -589,7 +589,7 @@
                      END DO
                   END DO
                ELSE
-                  wl = w*(ks*af + cs*am)
+                  wl = w*(ks*afu + cs*afv)
                   DO a=1, eNoN
                      DO b=1, eNoN
                         T1 = N(a)*N(b)

--- a/Code/Source/svFSILS/CMakeLists.txt
+++ b/Code/Source/svFSILS/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${MPI_C_INCLUDE_PATH})
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-  set(CMAKE_Fortran_FLAGS "-O3 -DNDEBUG -march=native")
+  set(CMAKE_Fortran_FLAGS "-O3 -DNDEBUG -march=cascadelake")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -pthread -std=legacy")
 
   # Use below flags for debugging


### PR DESCRIPTION
A macroscopic viscoelasticity has been implemented, with the second PK = \eta E_dot. \eta can be set using Viscosity under "Add equation" in both struct and ustruct. The default Viscosity is 0.

The Heaviside function is implemented for HO model and is approximated using a function \chi=\frac{1}{1+exp(-k(x-1))}. The default k is equal to 100 and can be set as a material parameter in HO model.