### PR TITLE
Removed https://doi.org/ prefix for JOSS paper bib file

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -67,7 +67,7 @@ volume = {208},
 pages = {106223},
 year = {2021},
 issn = {0169-2607},
-doi = {https://doi.org/10.1016/j.cmpb.2021.106223},
+doi = {10.1016/j.cmpb.2021.106223},
 url = {https://www.sciencedirect.com/science/article/pii/S0169260721002972},
 author = {Gernot Plank and Axel Loewe and Aurel Neic and Christoph Augustin and Yung-Lin Huang and Matthias A.F. Gsell and Elias Karabelas and Mark Nothstein and Anton J. Prassl and Jorge Sánchez and Gunnar Seemann and Edward J. Vigmond},
 }
@@ -171,7 +171,7 @@ keywords = {Blood flow, Hemodynamics, Mass transport, Endothelial cells},
     month = {09},
     issn = {0148-0731},
     doi = {10.1115/1.4048032},
-    url = {https://doi.org/10.1115/1.4048032},
+    url = {10.1115/1.4048032},
     note = {111011},
     eprint = {https://asmedigitalcollection.asme.org/biomechanical/article-pdf/142/11/111011/6565541/bio\_142\_11\_111011.pdf},
 }
@@ -185,7 +185,7 @@ keywords = {Blood flow, Hemodynamics, Mass transport, Endothelial cells},
   pages={397--423},
   year={2005},
   publisher={ACM New York, NY, USA},
-  url={https://doi.org/10.1145/1089014.1089021}
+  url={10.1145/1089014.1089021}
 }
 
 @article{quateroni_a,


### PR DESCRIPTION
Removed https://doi.org/ prefix for JOSS paper bib file