### PR TITLE
Bug fixes:

### DIFF
--- a/Code/Source/svFSI/CEPMOD_AP.f
+++ b/Code/Source/svFSI/CEPMOD_AP.f
@@ -410,7 +410,8 @@
          IF (TRIM(skwrd) .EQ. TRIM(scmd)) THEN
             READ(sval,*,IOSTAT=ios) rval
             IF (ios .NE. 0) THEN
-               STOP " Error: while reading "//TRIM(skwrd)
+               WRITE(*,'(A)') " Error: while reading "//TRIM(skwrd)
+               STOP
             END IF
             EXIT
          END IF
@@ -418,8 +419,9 @@
 
  001  RETURN
 
-!  001  STOP " Error: EOF reached while finding command <"//
+! 001  WRITE(*,'(A)') " Error: EOF reached while finding command <"//
 !     2   TRIM(skwrd)//">"
+!      STOP
 
       END SUBROUTINE GETRVAL
 !-----------------------------------------------------------------------

--- a/Code/Source/svFSI/CEPMOD_BO.f
+++ b/Code/Source/svFSI/CEPMOD_BO.f
@@ -741,7 +741,8 @@ c      dFa = alfa * dRFL * (c_c - c_0)**2
          IF (TRIM(skwrd) .EQ. TRIM(scmd)) THEN
             READ(sval,*,IOSTAT=ios) rval
             IF (ios .NE. 0) THEN
-               STOP " Error: while reading "//TRIM(skwrd)
+               WRITE(*,'(A)') " Error: while reading "//TRIM(skwrd)
+               STOP
             END IF
             EXIT
          END IF
@@ -749,8 +750,9 @@ c      dFa = alfa * dRFL * (c_c - c_0)**2
 
  001  RETURN
 
-! 001  STOP " Error: EOF reached while finding command <"//
+! 001  WRITE(*,'(A)') " Error: EOF reached while finding command <"//
 !     2   TRIM(skwrd)//">"
+!      STOP
 
       END SUBROUTINE GETRVAL
 !-----------------------------------------------------------------------
@@ -797,13 +799,16 @@ c      dFa = alfa * dRFL * (c_c - c_0)**2
                DO i=1, nt
                   WRITE(*,'(I2,2X,A)') i, TRIM(tokList(i))
                END DO
-               STOP " Error: Unexpected token length "//TRIM(skwrd)
+               WRITE(*,'(A)') " Error: Unexpected token length "//
+     2            TRIM(skwrd)
+               STOP
             END IF
 
             DO i=1, nt
                READ(tokList(i),*,IOSTAT=ios) rvec(i)
                IF (ios .NE. 0) THEN
-                  STOP " Error: while reading "//TRIM(skwrd)
+                  WRITE(*,'(A)') " Error: while reading "//TRIM(skwrd)
+                  STOP
                END IF
             END DO
             EXIT
@@ -812,8 +817,9 @@ c      dFa = alfa * dRFL * (c_c - c_0)**2
 
       RETURN
 
- 001  STOP " Error: EOF reached while finding command <"//
+ 001  WRITE(*,'(A)') " Error: EOF reached while finding command <"//
      2   TRIM(skwrd)//">"
+      STOP
 
       END SUBROUTINE GETRVEC
 !-----------------------------------------------------------------------

--- a/Code/Source/svFSI/CEPMOD_FN.f
+++ b/Code/Source/svFSI/CEPMOD_FN.f
@@ -294,7 +294,8 @@
          IF (TRIM(skwrd) .EQ. TRIM(scmd)) THEN
             READ(sval,*,IOSTAT=ios) rval
             IF (ios .NE. 0) THEN
-               STOP " Error: while reading "//TRIM(skwrd)
+               WRITE(*,'(A)') " Error: while reading "//TRIM(skwrd)
+               STOP
             END IF
             EXIT
          END IF
@@ -302,8 +303,9 @@
 
  001  RETURN
 
-!  001  STOP " Error: EOF reached while finding command <"//
+! 001  WRITE(*,'(A)') " Error: EOF reached while finding command <"//
 !     2   TRIM(skwrd)//">"
+!      STOP
 
       END SUBROUTINE GETRVAL
 !-----------------------------------------------------------------------

--- a/Code/Source/svFSI/CEPMOD_TTP.f
+++ b/Code/Source/svFSI/CEPMOD_TTP.f
@@ -1234,7 +1234,8 @@ c      dFa = alfa * dRFL * (c_Ca - c_Ca0)**2
          IF (TRIM(skwrd) .EQ. TRIM(scmd)) THEN
             READ(sval,*,IOSTAT=ios) rval
             IF (ios .NE. 0) THEN
-               STOP " Error: while reading "//TRIM(skwrd)
+               WRITE(*,'(A)') " Error: while reading "//TRIM(skwrd)
+               STOP
             END IF
             EXIT
          END IF
@@ -1242,8 +1243,9 @@ c      dFa = alfa * dRFL * (c_Ca - c_Ca0)**2
 
  001  RETURN
 
-! 001  STOP " Error: EOF reached while finding command <"//
+! 001  WRITE(*,'(A)') " Error: EOF reached while finding command <"//
 !     2   TRIM(skwrd)//">"
+!      STOP
 
       END SUBROUTINE GETRVAL
 !-----------------------------------------------------------------------
@@ -1290,13 +1292,16 @@ c      dFa = alfa * dRFL * (c_Ca - c_Ca0)**2
                DO i=1, nt
                   WRITE(*,'(I2,2X,A)') i, TRIM(tokList(i))
                END DO
-               STOP " Error: Unexpected token length "//TRIM(skwrd)
+               WRITE(*,'(A)') " Error: Unexpected token length "//
+     2            TRIM(skwrd)
+               STOP
             END IF
 
             DO i=1, nt
                READ(tokList(i),*,IOSTAT=ios) rvec(i)
                IF (ios .NE. 0) THEN
-                  STOP " Error: while reading "//TRIM(skwrd)
+                  WRITE(*,'(A)') " Error: while reading "//TRIM(skwrd)
+                  STOP
                END IF
             END DO
             EXIT
@@ -1305,8 +1310,9 @@ c      dFa = alfa * dRFL * (c_Ca - c_Ca0)**2
 
  001  RETURN
 
-! 001  STOP " Error: EOF reached while finding command <"//
+! 001  WRITE(*,'(A)') " Error: EOF reached while finding command <"//
 !     2   TRIM(skwrd)//">"
+!      STOP
 
       END SUBROUTINE GETRVEC
 !-----------------------------------------------------------------------

--- a/Code/Source/svFSI/ECMOD_DCPLD.f
+++ b/Code/Source/svFSI/ECMOD_DCPLD.f
@@ -239,7 +239,8 @@
          IF (TRIM(skwrd) .EQ. TRIM(scmd)) THEN
             READ(sval,*,IOSTAT=ios) rval
             IF (ios .NE. 0) THEN
-               STOP " Error: while reading "//TRIM(skwrd)
+               WRITE(*,'(A)') " Error: while reading "//TRIM(skwrd)
+               STOP
             END IF
             EXIT
          END IF
@@ -247,8 +248,9 @@
 
  001  RETURN
 
-!  001  STOP " Error: EOF reached while finding command <"//
+! 001  WRITE(*,'(A)') " Error: EOF reached while finding command <"//
 !     2   TRIM(skwrd)//">"
+!      STOP
 
       END SUBROUTINE GETRVAL
 !-----------------------------------------------------------------------

--- a/Code/Source/svFSI/FSI.f
+++ b/Code/Source/svFSI/FSI.f
@@ -51,8 +51,8 @@
 
       INTEGER(KIND=IKIND), ALLOCATABLE :: ptr(:)
       REAL(KIND=RKIND), ALLOCATABLE :: xl(:,:), al(:,:), yl(:,:),
-     2   dl(:,:), bfl(:,:), fN(:,:), pS0l(:,:), pSl(:), ya_l(:),
-     3   lR(:,:), lK(:,:,:), lKd(:,:,:)
+     2   dl(:,:), bfl(:,:), fN(:,:), pS0l(:,:), pSl(:), tmXl(:),
+     3   ya_l(:), lR(:,:), lK(:,:,:), lKd(:,:,:)
       REAL(KIND=RKIND), ALLOCATABLE :: xwl(:,:), xql(:,:), Nwx(:,:),
      2   Nwxx(:,:), Nqx(:,:)
 
@@ -71,8 +71,8 @@
 
       ALLOCATE(ptr(eNoN), xl(nsd,eNoN), al(tDof,eNoN), yl(tDof,eNoN),
      2   dl(tDof,eNoN), bfl(nsd,eNoN), fN(nsd,nFn), pS0l(nsymd,eNoN),
-     3   pSl(nsymd), ya_l(eNoN), lR(dof,eNoN), lK(dof*dof,eNoN,eNoN),
-     4   lKd(dof*nsd,eNoN,eNoN))
+     3   pSl(nsymd), tmXl(eNoN), ya_l(eNoN), lR(dof,eNoN),
+     4   lK(dof*dof,eNoN,eNoN), lKd(dof*nsd,eNoN,eNoN))
 
 !     Loop over all elements of mesh
       DO e=1, lM%nEl
@@ -105,6 +105,9 @@
             END IF
             IF (ALLOCATED(pS0)) pS0l(:,a) = pS0(:,Ac)
             IF (ecCpld) THEN
+               IF (ALLOCATED(lM%tmX)) THEN
+                  tmXl(a) = lM%tmX(lM%lN(Ac))
+               END IF
                IF (ALLOCATED(ec_Ya)) THEN
                   ya_l(a) = ec_Ya(Ac)
                ELSE
@@ -167,12 +170,12 @@
 
                CASE (phys_struct)
                   CALL STRUCT3D(fs(1)%eNoN, nFn, w, fs(1)%N(:,g), Nwx,
-     2               al, yl, dl, bfl, fN, pS0l, pSl, ya_l, lR, lK)
+     2               al, yl, dl, bfl, fN, pS0l, pSl, tmXl, ya_l, lR, lK)
 
                CASE (phys_ustruct)
                   CALL USTRUCT3D_M(vmsStab, fs(1)%eNoN, fs(2)%eNoN, nFn,
      2               w, Jac, fs(1)%N(:,g), fs(2)%N(:,g), Nwx, al, yl,
-     3               dl, bfl, fN, ya_l, lR, lK, lKd)
+     3               dl, bfl, fN, tmXl, ya_l, lR, lK, lKd)
 
                END SELECT
 
@@ -189,12 +192,12 @@
 
                CASE (phys_struct)
                   CALL STRUCT2D(fs(1)%eNoN, nFn, w, fs(1)%N(:,g), Nwx,
-     2               al, yl, dl, bfl, fN, pS0l, pSl, ya_l, lR, lK)
+     2               al, yl, dl, bfl, fN, pS0l, pSl, tmXl, ya_l, lR, lK)
 
                CASE (phys_ustruct)
                   CALL USTRUCT2D_M(vmsStab, fs(1)%eNoN, fs(2)%eNoN, nFn,
      2               w, Jac, fs(1)%N(:,g), fs(2)%N(:,g), Nwx, al, yl,
-     3               dl, bfl, fN, ya_l, lR, lK, lKd)
+     3               dl, bfl, fN, tmXl, ya_l, lR, lK, lKd)
 
                END SELECT
             END IF
@@ -266,8 +269,8 @@
 #endif
       END DO ! e: loop
 
-      DEALLOCATE(ptr, xl, al, yl, dl, bfl, fN, pS0l, pSl, ya_l, lR, lK,
-     2   lKd)
+      DEALLOCATE(ptr, xl, al, yl, dl, bfl, fN, pS0l, pSl, tmXl, ya_l,
+     2    lR, lK, lKd)
 
       CALL DESTROY(fs(1))
       CALL DESTROY(fs(2))

--- a/Code/Source/svFSI/TXT.f
+++ b/Code/Source/svFSI/TXT.f
@@ -75,8 +75,10 @@
                   OPEN(fid, FILE=cplBC%saveName, POSITION='APPEND')
                   WRITE(fid,'(ES14.6E2)',ADVANCE='NO') cplBC%xp(1)
                   DO i=1, cplBC%nX
-                     WRITE(fid,'(2(1X,ES14.6E2))',ADVANCE='NO')
-     2                  cplBC%xn(i), cplBC%fa(i)%y
+                     WRITE(fid,'(ES14.6E2)',ADVANCE='NO') cplBC%xn(i)
+                  END DO
+                  DO i=1, cplBC%nFa
+                     WRITE(fid,'(ES14.6E2)',ADVANCE='NO') cplBC%fa(i)%y
                   END DO
                   DO i=2, cplBC%nXp
                      WRITE(fid,'(ES14.6E2)',ADVANCE='NO') cplBC%xp(i)


### PR DESCRIPTION
- Writing cplBC output to file
- Included transmural distance (tmX) in FSI.f for function calls to STRUCT and USTRUCT
- Removed appending string keywords to STOP messages - specifically for Intel compilers to avoid compile errors